### PR TITLE
feat: admin model management — add/remove any OpenAI-compatible model from bot

### DIFF
--- a/docs/plans/2026-04-03-model-management-design.md
+++ b/docs/plans/2026-04-03-model-management-design.md
@@ -1,0 +1,70 @@
+# Model Management — Design
+
+## Goal
+
+Allow admins to add, remove, and configure any OpenAI-compatible model (including OpenRouter) from the Telegram bot interface, with per-preset API keys and access control.
+
+## Data Model
+
+New table `model_presets` in SQLite:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | INTEGER PK | Auto-increment |
+| `key` | TEXT UNIQUE | Slug generated from model_id |
+| `name` | TEXT | Display name |
+| `model` | TEXT | Model ID for API |
+| `base_url` | TEXT | API endpoint URL |
+| `api_key` | TEXT NULL | Optional per-preset key (NULL = global) |
+| `admin_only` | BOOLEAN DEFAULT FALSE | Restrict to admins |
+| `is_enabled` | BOOLEAN DEFAULT TRUE | Enabled/disabled |
+| `created_at` | TIMESTAMP | Creation date |
+
+On startup, presets from `.env` (`OPENAI_MODELS`) are synced into DB via upsert on `key`.
+
+## Admin Interface
+
+### Quick add via command
+
+```
+/add_model google/gemini-2.0-flash "Gemini Flash" https://openrouter.ai/api/v1
+```
+
+Format: `/add_model <model_id> "<name>" <base_url> [api_key]`
+
+`key` auto-generated from model_id (e.g. `google_gemini-2_0-flash`).
+
+### Management via `/models`
+
+List view with inline buttons. Tap a model to see detail card with actions:
+- Edit name, URL, API key (step-by-step dialog)
+- Toggle access (all users / admin only)
+- Enable/disable
+- Delete
+
+### Sync button
+
+"Sync from .env" re-imports `OPENAI_MODELS` presets into DB.
+
+## OpenAIProvider Changes
+
+Client cache by `(base_url, api_key)` tuple:
+- `_get_client(preset)` returns cached or new `openai.OpenAI` instance
+- `generate_protocol()` resolves preset, uses `_get_client(preset)` instead of `self.client`
+- Global client remains default fallback
+
+## Access Control
+
+`model_preset_repo.get_available_for_user(user_id)`:
+- `is_enabled=False` → hidden from everyone (visible in admin `/models`)
+- `admin_only=True` → visible only to admins
+- Otherwise → visible to all
+
+Settings UI (`settings_callbacks.py`) uses this method for filtering.
+
+## Backward Compatibility
+
+- Existing `OPENAI_MODELS` env var continues to work
+- Legacy `OPENAI_MODEL` + `OPENAI_BASE_URL` auto-creates a default preset
+- User's `preferred_openai_model_key` works unchanged
+- If preset is deleted and user still references it, falls back to default

--- a/docs/plans/2026-04-03-model-management-plan.md
+++ b/docs/plans/2026-04-03-model-management-plan.md
@@ -1,0 +1,747 @@
+# Model Management Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable admins to add, remove, and configure any OpenAI-compatible model (including OpenRouter) from the Telegram bot interface, with per-preset API keys and user access control.
+
+**Architecture:** New `model_presets` table in SQLite with a repository layer. Admin commands (`/add_model`, `/models`) for CRUD. OpenAIProvider gets a client cache for per-preset `base_url`/`api_key`. Settings UI reads presets from DB instead of config. On startup, `.env` presets sync into DB.
+
+**Tech Stack:** Python 3.11+, aiogram 3.x, aiosqlite, OpenAI SDK
+
+---
+
+### Task 1: Database — model_presets table
+
+**Files:**
+- Modify: `src/database/database.py:17` — add CREATE TABLE in `init_db()`
+- Create: `src/database/model_preset_repo.py`
+
+**Step 1: Add table creation to `init_db()`**
+
+In `src/database/database.py`, inside `init_db()`, after the existing CREATE TABLE statements, add:
+
+```python
+            # Таблица пресетов моделей
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS model_presets (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE NOT NULL,
+                    name TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    base_url TEXT NOT NULL,
+                    api_key TEXT,
+                    admin_only BOOLEAN DEFAULT 0,
+                    is_enabled BOOLEAN DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+```
+
+**Step 2: Create `src/database/model_preset_repo.py`**
+
+Follow the pattern from `src/database/user_repo.py`:
+
+```python
+"""Model preset data access."""
+import aiosqlite
+from typing import Optional, List, Dict, Any
+from loguru import logger
+
+
+class ModelPresetRepository:
+    """Repository for model preset CRUD operations."""
+
+    def __init__(self, database):
+        self._db = database
+
+    async def get_all(self) -> List[Dict[str, Any]]:
+        """Get all model presets."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets ORDER BY created_at"
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
+
+    async def get_enabled(self) -> List[Dict[str, Any]]:
+        """Get enabled presets."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets WHERE is_enabled = 1 ORDER BY created_at"
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
+
+    async def get_available_for_user(self, user_id: int) -> List[Dict[str, Any]]:
+        """Get presets available to a specific user (filters admin_only)."""
+        from src.utils.admin_utils import is_admin
+        presets = await self.get_enabled()
+        if is_admin(user_id):
+            return presets
+        return [p for p in presets if not p['admin_only']]
+
+    async def get_by_key(self, key: str) -> Optional[Dict[str, Any]]:
+        """Get preset by key."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets WHERE key = ?", (key,)
+            )
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def upsert(self, key: str, name: str, model: str, base_url: str,
+                     api_key: str = None, admin_only: bool = False) -> int:
+        """Insert or update a preset by key."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            cursor = await db.execute("""
+                INSERT INTO model_presets (key, name, model, base_url, api_key, admin_only)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    name = excluded.name,
+                    model = excluded.model,
+                    base_url = excluded.base_url,
+                    api_key = COALESCE(excluded.api_key, model_presets.api_key),
+                    admin_only = excluded.admin_only
+            """, (key, name, model, base_url, api_key, admin_only))
+            await db.commit()
+            return cursor.lastrowid
+
+    async def update_field(self, key: str, field: str, value: Any) -> bool:
+        """Update a single field on a preset."""
+        allowed_fields = {'name', 'model', 'base_url', 'api_key', 'admin_only', 'is_enabled'}
+        if field not in allowed_fields:
+            raise ValueError(f"Field {field} not allowed")
+        async with aiosqlite.connect(self._db.db_path) as db:
+            cursor = await db.execute(
+                f"UPDATE model_presets SET {field} = ? WHERE key = ?",
+                (value, key)
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def delete(self, key: str) -> bool:
+        """Delete a preset by key."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            cursor = await db.execute(
+                "DELETE FROM model_presets WHERE key = ?", (key,)
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+```
+
+**Step 3: Verify syntax**
+
+Run: `python -m py_compile src/database/model_preset_repo.py`
+
+**Step 4: Commit**
+
+```bash
+git add src/database/database.py src/database/model_preset_repo.py
+git commit -m "feat: model_presets table and repository"
+```
+
+---
+
+### Task 2: Startup sync — import .env presets into DB
+
+**Files:**
+- Modify: `src/bot.py` — add sync call during startup
+
+**Step 1: Create sync function**
+
+Add to `src/database/model_preset_repo.py`:
+
+```python
+    async def sync_from_config(self) -> int:
+        """Import presets from settings.openai_models into DB. Returns count synced."""
+        from config import settings
+        count = 0
+        for preset in settings.openai_models:
+            await self.upsert(
+                key=preset.key,
+                name=preset.name,
+                model=preset.model,
+                base_url=preset.base_url or settings.openai_base_url or "https://api.openai.com/v1",
+            )
+            count += 1
+        logger.info(f"Синхронизировано {count} пресетов моделей из конфигурации")
+        return count
+```
+
+**Step 2: Add sync call to bot startup**
+
+In `src/bot.py`, find the `start()` or `__init__` method where `db.init_db()` is called. After that call, add:
+
+```python
+from src.database.model_preset_repo import ModelPresetRepository
+model_preset_repo = ModelPresetRepository(db)
+await model_preset_repo.sync_from_config()
+```
+
+Also expose `model_preset_repo` so handlers can import it. Add to `src/database/__init__.py` or create a module-level instance like the existing `db` singleton.
+
+**Step 3: Verify syntax**
+
+Run: `python -m py_compile src/bot.py`
+
+**Step 4: Commit**
+
+```bash
+git add src/database/model_preset_repo.py src/bot.py
+git commit -m "feat: sync .env model presets into DB on startup"
+```
+
+---
+
+### Task 3: Admin commands — /add_model and /models
+
+**Files:**
+- Modify: `src/handlers/admin_handlers.py` — add new handlers
+- Use FSM for editing dialogs
+
+**Step 1: Add `/add_model` command handler**
+
+In `src/handlers/admin_handlers.py`, inside `setup_admin_handlers()`, add:
+
+```python
+    @router.message(Command("add_model"))
+    async def add_model_handler(message: Message):
+        """Add a new model preset. Format: /add_model <model_id> "<name>" <base_url> [api_key]"""
+        if not is_admin(message.from_user.id):
+            await message.answer("❌ Недостаточно прав.")
+            return
+
+        import re
+        args = message.text.replace("/add_model", "", 1).strip()
+        if not args:
+            await message.answer(
+                "📝 Формат: `/add_model model_id \"Название\" base_url [api_key]`\n\n"
+                "Пример:\n"
+                "`/add_model google/gemini-2.0-flash \"Gemini Flash\" https://openrouter.ai/api/v1`",
+                parse_mode="Markdown"
+            )
+            return
+
+        # Parse: model_id "name" base_url [api_key]
+        match = re.match(r'(\S+)\s+"([^"]+)"\s+(\S+)(?:\s+(\S+))?', args)
+        if not match:
+            await message.answer("❌ Неверный формат. Используй: `/add_model model_id \"Название\" base_url [api_key]`", parse_mode="Markdown")
+            return
+
+        model_id, name, base_url, api_key = match.groups()
+        key = re.sub(r'[^a-zA-Z0-9_-]', '_', model_id)
+
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        await repo.upsert(key=key, name=name, model=model_id, base_url=base_url, api_key=api_key)
+
+        await message.answer(
+            f"✅ Модель добавлена:\n\n"
+            f"📌 **{name}**\n"
+            f"Model: `{model_id}`\n"
+            f"URL: `{base_url}`\n"
+            f"API Key: {'✅ задан' if api_key else '🔑 глобальный'}\n"
+            f"Key: `{key}`",
+            parse_mode="Markdown"
+        )
+```
+
+**Step 2: Add `/models` command handler with inline keyboard**
+
+```python
+    @router.message(Command("models"))
+    async def models_handler(message: Message):
+        """List and manage model presets."""
+        if not is_admin(message.from_user.id):
+            await message.answer("❌ Недостаточно прав.")
+            return
+
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        presets = await repo.get_all()
+
+        if not presets:
+            await message.answer("Нет настроенных моделей. Используй /add_model для добавления.")
+            return
+
+        lines = ["📋 **Модели:**\n"]
+        keyboard_rows = []
+        for i, p in enumerate(presets, 1):
+            status = "✅" if p['is_enabled'] else "⛔"
+            access = " 🔒" if p['admin_only'] else ""
+            lines.append(f"{i}. {status} **{p['name']}**{access}\n   `{p['model']}`")
+            keyboard_rows.append([InlineKeyboardButton(
+                text=f"{status} {p['name']}",
+                callback_data=f"admin_model_{p['key']}"
+            )])
+
+        keyboard_rows.append([
+            InlineKeyboardButton(text="🔄 Синхр. из .env", callback_data="admin_models_sync")
+        ])
+
+        await message.answer(
+            "\n".join(lines),
+            parse_mode="Markdown",
+            reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard_rows)
+        )
+```
+
+**Step 3: Add callback handlers for model detail card and actions**
+
+```python
+    @router.callback_query(F.data.startswith("admin_model_"))
+    async def admin_model_detail_callback(callback: CallbackQuery):
+        """Show model detail card with action buttons."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+
+        key = callback.data.replace("admin_model_", "")
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        p = await repo.get_by_key(key)
+
+        if not p:
+            await callback.answer("Модель не найдена")
+            return
+
+        status = "✅ включена" if p['is_enabled'] else "⛔ выключена"
+        access = "🔒 только админы" if p['admin_only'] else "👥 все пользователи"
+        api_info = "🔑 свой ключ" if p['api_key'] else "🌐 глобальный"
+
+        text = (
+            f"**{p['name']}**\n\n"
+            f"Model: `{p['model']}`\n"
+            f"URL: `{p['base_url']}`\n"
+            f"API Key: {api_info}\n"
+            f"Статус: {status}\n"
+            f"Доступ: {access}"
+        )
+
+        toggle_enabled = "✅ Включить" if not p['is_enabled'] else "⛔ Выключить"
+        toggle_access = "👥 Для всех" if p['admin_only'] else "🔒 Только админы"
+
+        keyboard = InlineKeyboardMarkup(inline_keyboard=[
+            [
+                InlineKeyboardButton(text=toggle_enabled, callback_data=f"admin_model_toggle_{key}"),
+                InlineKeyboardButton(text=toggle_access, callback_data=f"admin_model_access_{key}"),
+            ],
+            [
+                InlineKeyboardButton(text="🗑 Удалить", callback_data=f"admin_model_delete_{key}"),
+            ],
+            [InlineKeyboardButton(text="⬅️ К списку", callback_data="admin_models_list")],
+        ])
+
+        await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        await callback.answer()
+
+    @router.callback_query(F.data.startswith("admin_model_toggle_"))
+    async def admin_model_toggle_callback(callback: CallbackQuery):
+        """Toggle model enabled/disabled."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+        key = callback.data.replace("admin_model_toggle_", "")
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        p = await repo.get_by_key(key)
+        if p:
+            await repo.update_field(key, "is_enabled", not p['is_enabled'])
+        # Re-render detail card
+        callback.data = f"admin_model_{key}"
+        await admin_model_detail_callback(callback)
+
+    @router.callback_query(F.data.startswith("admin_model_access_"))
+    async def admin_model_access_callback(callback: CallbackQuery):
+        """Toggle model admin_only flag."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+        key = callback.data.replace("admin_model_access_", "")
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        p = await repo.get_by_key(key)
+        if p:
+            await repo.update_field(key, "admin_only", not p['admin_only'])
+        callback.data = f"admin_model_{key}"
+        await admin_model_detail_callback(callback)
+
+    @router.callback_query(F.data.startswith("admin_model_delete_"))
+    async def admin_model_delete_callback(callback: CallbackQuery):
+        """Delete a model preset."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+        key = callback.data.replace("admin_model_delete_", "")
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        await repo.delete(key)
+        await callback.answer(f"🗑 Модель {key} удалена")
+        # Return to list
+        callback.data = "admin_models_list"
+        await admin_models_list_callback(callback)
+
+    @router.callback_query(F.data == "admin_models_sync")
+    async def admin_models_sync_callback(callback: CallbackQuery):
+        """Sync presets from .env into DB."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        count = await repo.sync_from_config()
+        await callback.answer(f"🔄 Синхронизировано {count} моделей из .env")
+        callback.data = "admin_models_list"
+        await admin_models_list_callback(callback)
+
+    @router.callback_query(F.data == "admin_models_list")
+    async def admin_models_list_callback(callback: CallbackQuery):
+        """Re-render model list (callback version of /models)."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав.")
+            return
+        from src.database.model_preset_repo import ModelPresetRepository
+        from database import db
+        repo = ModelPresetRepository(db)
+        presets = await repo.get_all()
+
+        if not presets:
+            await safe_edit_text(callback.message, "Нет настроенных моделей.")
+            await callback.answer()
+            return
+
+        lines = ["📋 **Модели:**\n"]
+        keyboard_rows = []
+        for i, p in enumerate(presets, 1):
+            status = "✅" if p['is_enabled'] else "⛔"
+            access = " 🔒" if p['admin_only'] else ""
+            lines.append(f"{i}. {status} **{p['name']}**{access}\n   `{p['model']}`")
+            keyboard_rows.append([InlineKeyboardButton(
+                text=f"{status} {p['name']}",
+                callback_data=f"admin_model_{p['key']}"
+            )])
+        keyboard_rows.append([
+            InlineKeyboardButton(text="🔄 Синхр. из .env", callback_data="admin_models_sync")
+        ])
+
+        await safe_edit_text(
+            callback.message,
+            "\n".join(lines),
+            reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard_rows),
+            parse_mode="Markdown"
+        )
+        await callback.answer()
+```
+
+**Step 4: Update admin help text**
+
+In `admin_help_handler` (line 298), add to help_text:
+
+```
+**Управление моделями:**
+• `/models` - список и управление моделями
+• `/add_model` - добавить модель
+```
+
+**Step 5: Verify syntax**
+
+Run: `python -m py_compile src/handlers/admin_handlers.py`
+
+**Step 6: Commit**
+
+```bash
+git add src/handlers/admin_handlers.py
+git commit -m "feat: admin commands /add_model and /models with inline UI"
+```
+
+---
+
+### Task 4: OpenAIProvider — per-preset client cache
+
+**Files:**
+- Modify: `src/llm/providers/openai_provider.py:21-77` — add client cache, use preset base_url/api_key
+
+**Step 1: Add client cache to `__init__`**
+
+Replace `__init__` (lines 24-34):
+
+```python
+    def __init__(self):
+        self.default_client = None
+        self.http_client = None
+        self._client_cache = {}  # (base_url, api_key_hash) -> openai.OpenAI
+        if settings.openai_api_key:
+            openai.api_key = settings.openai_api_key
+            self.http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
+            self.default_client = openai.OpenAI(
+                api_key=settings.openai_api_key,
+                base_url=settings.openai_base_url,
+                http_client=self.http_client
+            )
+```
+
+**Step 2: Add `_get_client` method**
+
+```python
+    def _get_client(self, preset: dict = None) -> openai.OpenAI:
+        """Get or create an OpenAI client for the given preset."""
+        if not preset:
+            return self.default_client
+
+        base_url = preset.get('base_url') or settings.openai_base_url
+        api_key = preset.get('api_key') or settings.openai_api_key
+
+        cache_key = (base_url, hash(api_key) if api_key else None)
+
+        if cache_key not in self._client_cache:
+            http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
+            self._client_cache[cache_key] = openai.OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=http_client,
+            )
+            logger.info(f"Создан клиент для {base_url}")
+
+        return self._client_cache[cache_key]
+```
+
+**Step 3: Update `generate_protocol` to resolve preset from DB**
+
+Replace lines 67-77 (model selection block):
+
+```python
+        selected_model = settings.openai_model
+        openai_model_key = kwargs.get('openai_model_key')
+        preset_dict = None
+
+        if openai_model_key:
+            try:
+                # Try DB first, fall back to config
+                import asyncio
+                from src.database.model_preset_repo import ModelPresetRepository
+                from database import db
+                repo = ModelPresetRepository(db)
+                preset_dict = await repo.get_by_key(openai_model_key)
+
+                if preset_dict:
+                    selected_model = preset_dict['model']
+                    logger.info(f"Используется модель из БД: {selected_model} (ключ: {openai_model_key})")
+                else:
+                    # Fallback to config presets
+                    preset = next((p for p in settings.openai_models if p.key == openai_model_key), None)
+                    if preset:
+                        selected_model = preset.model
+                        preset_dict = {'base_url': preset.base_url, 'api_key': None}
+                        logger.info(f"Используется модель из конфига: {selected_model} (ключ: {openai_model_key})")
+            except Exception as e:
+                logger.warning(f"Не удалось определить модель по ключу {openai_model_key}: {e}")
+```
+
+**Step 4: Update `_call_openai` to accept a client**
+
+Change `_call_openai` signature (line 141) to accept optional `client` parameter:
+
+```python
+    async def _call_openai(self, system_prompt: str, user_prompt: str, schema: Dict[str, Any],
+                           step_name: str, model: str = None, client: openai.OpenAI = None) -> Dict[str, Any]:
+        """Helper method for OpenAI API calls."""
+        selected_model = model or settings.openai_model
+        active_client = client or self.default_client
+```
+
+Then replace `self.client.chat.completions.create` with `active_client.chat.completions.create` in `_api_call()` (line 155-156).
+
+**Step 5: Pass client to `_call_openai` calls**
+
+In `generate_protocol()`, when calling `_call_openai` for Stage 2 (line 122):
+
+```python
+        client = self._get_client(preset_dict)
+
+        generation_result = await self._call_openai(
+            system_prompt=generation_system_prompt,
+            user_prompt=generation_user_prompt,
+            schema=PROTOCOL_DATA_SCHEMA,
+            step_name="Generation",
+            model=selected_model,
+            client=client
+        )
+```
+
+Stage 1 analysis uses `settings.analysis_stage_model` (not user preset), so no client override needed.
+
+**Step 6: Update `is_available`**
+
+```python
+    def is_available(self) -> bool:
+        return self.default_client is not None and settings.openai_api_key is not None
+```
+
+**Step 7: Verify syntax**
+
+Run: `python -m py_compile src/llm/providers/openai_provider.py`
+
+**Step 8: Commit**
+
+```bash
+git add src/llm/providers/openai_provider.py
+git commit -m "feat: per-preset client cache in OpenAIProvider"
+```
+
+---
+
+### Task 5: Settings UI — read presets from DB
+
+**Files:**
+- Modify: `src/handlers/callbacks/settings_callbacks.py:52-87` — load from DB with access filtering
+
+**Step 1: Update `settings_openai_model_callback`**
+
+Replace lines 52-87 to load from DB:
+
+```python
+    @router.callback_query(F.data == "settings_openai_model")
+    async def settings_openai_model_callback(callback: CallbackQuery):
+        """Обработчик меню выбора модели OpenAI"""
+        try:
+            from src.database.model_preset_repo import ModelPresetRepository
+            from database import db as app_db
+            repo = ModelPresetRepository(app_db)
+            presets = await repo.get_available_for_user(callback.from_user.id)
+
+            if not presets:
+                await safe_edit_text(callback.message,
+                    "❌ Нет доступных моделей.\n\n"
+                    "Администратор может добавить модели командой /add_model.",
+                    reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                        [InlineKeyboardButton(text="⬅️ Назад к настройкам", callback_data="back_to_settings")]
+                    ])
+                )
+                await callback.answer()
+                return
+
+            user = await user_service.get_user_by_telegram_id(callback.from_user.id)
+            selected_key = getattr(user, 'preferred_openai_model_key', None) if user else None
+
+            keyboard_rows = []
+            for p in presets:
+                label = f"{'✅ ' if selected_key == p['key'] else ''}{p['name']}"
+                keyboard_rows.append([InlineKeyboardButton(text=label, callback_data=f"set_openai_model_{p['key']}")])
+            keyboard_rows.append([InlineKeyboardButton(text="🔄 Сбросить выбор модели", callback_data="reset_openai_model_preference")])
+            keyboard_rows.append([InlineKeyboardButton(text="⬅️ Назад к настройкам", callback_data="back_to_settings")])
+
+            await safe_edit_text(callback.message,
+                "🧠 **Модель OpenAI**\n\n"
+                "Выберите модель:",
+                reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard_rows)
+            )
+            await callback.answer()
+        except Exception as e:
+            logger.error(f"Ошибка в settings_openai_model_callback: {e}")
+            await callback.answer("❌ Не удалось загрузить модели OpenAI")
+```
+
+**Step 2: Update `set_openai_model_callback`**
+
+Replace lines 89-112 to look up name from DB:
+
+```python
+    @router.callback_query(F.data.startswith("set_openai_model_"))
+    async def set_openai_model_callback(callback: CallbackQuery):
+        """Устанавливает предпочитаемую модель OpenAI"""
+        try:
+            model_key = callback.data.replace("set_openai_model_", "")
+            await user_service.update_user_openai_model_preference(callback.from_user.id, model_key)
+
+            # Get display name from DB
+            from src.database.model_preset_repo import ModelPresetRepository
+            from database import db as app_db
+            repo = ModelPresetRepository(app_db)
+            preset = await repo.get_by_key(model_key)
+            model_name = preset['name'] if preset else model_key
+
+            await safe_edit_text(callback.message,
+                f"✅ Модель обновлена: {model_name}.\n\n"
+                "Она будет использоваться при выборе провайдера OpenAI.",
+                reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                    [InlineKeyboardButton(text="⬅️ Назад к настройкам", callback_data="back_to_settings")]
+                ])
+            )
+            await callback.answer()
+        except Exception as e:
+            logger.error(f"Ошибка в set_openai_model_callback: {e}")
+            await callback.answer("❌ Не удалось сохранить выбор модели")
+```
+
+**Step 3: Verify syntax**
+
+Run: `python -m py_compile src/handlers/callbacks/settings_callbacks.py`
+
+**Step 4: Commit**
+
+```bash
+git add src/handlers/callbacks/settings_callbacks.py
+git commit -m "feat: settings UI reads model presets from DB"
+```
+
+---
+
+### Task 6: LLM generation — resolve preset display name from DB
+
+**Files:**
+- Modify: `src/services/processing/llm_generation.py` — update `_get_model_display_name` or equivalent
+
+**Step 1: Find where display name is resolved**
+
+Grep for `get_model_display_name` in `src/services/processing/` and update to check DB first:
+
+```python
+# In the method that resolves display name:
+from src.database.model_preset_repo import ModelPresetRepository
+from database import db
+repo = ModelPresetRepository(db)
+preset = await repo.get_by_key(openai_model_key)
+if preset:
+    return preset['name']
+# else fall back to config lookup
+```
+
+**Step 2: Handle deleted preset gracefully**
+
+If user has `preferred_openai_model_key` pointing to a deleted preset, fall back to default model. This already works because the DB lookup returns None and the existing fallback logic applies.
+
+**Step 3: Verify syntax**
+
+**Step 4: Commit**
+
+```bash
+git add src/services/processing/llm_generation.py
+git commit -m "feat: resolve model display name from DB"
+```
+
+---
+
+## Verification Plan
+
+After all tasks:
+
+1. **Bot starts**: `python main.py` — no errors, presets synced from .env
+2. **Admin adds model**: `/add_model google/gemini-2.0-flash "Gemini Flash" https://openrouter.ai/api/v1` — confirms success
+3. **Admin lists models**: `/models` — shows all presets with inline buttons
+4. **Admin toggles access**: Click model → toggle "только админы" → verify non-admin doesn't see it
+5. **Admin disables model**: Click model → "Выключить" → verify removed from user settings
+6. **Admin deletes model**: Click model → "Удалить" → verify removed from list
+7. **User selects model**: Settings → Модель → sees only available models
+8. **Processing works**: Upload audio, select OpenRouter model → protocol generated via correct API endpoint
+9. **Sync works**: Click "Синхр. из .env" → presets from .env re-imported
+10. **Fallback works**: Delete user's selected preset → processing uses default model

--- a/src/bot.py
+++ b/src/bot.py
@@ -228,7 +228,12 @@ class EnhancedTelegramBot:
             # 1. Инициализируем базу данных
             await db.init_db()
             logger.info("База данных инициализирована")
-            
+
+            # 1.5. Синхронизация пресетов моделей из .env в БД
+            from src.database.model_preset_repo import ModelPresetRepository
+            model_preset_repo = ModelPresetRepository(db)
+            await model_preset_repo.sync_from_config()
+
             # 2. Инициализируем базовые шаблоны
             await self.template_service.init_default_templates()
             logger.info("Стандартные шаблоны синхронизированы и готовы к работе")

--- a/src/database/database.py
+++ b/src/database/database.py
@@ -216,6 +216,21 @@ class Database:
                 )
             """)
             
+            # Таблица пресетов моделей
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS model_presets (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE NOT NULL,
+                    name TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    base_url TEXT NOT NULL,
+                    api_key TEXT,
+                    admin_only BOOLEAN DEFAULT 0,
+                    is_enabled BOOLEAN DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
             # Миграция: консолидация шаблонов (27 -> 7)
             await self._consolidate_templates(db)
 

--- a/src/database/model_preset_repo.py
+++ b/src/database/model_preset_repo.py
@@ -1,0 +1,146 @@
+"""Model preset data access."""
+
+import aiosqlite
+from typing import Optional, List, Dict, Any
+from loguru import logger
+
+
+# Whitelist of fields allowed in update_field
+_ALLOWED_FIELDS = frozenset({
+    "name", "model", "base_url", "api_key",
+    "admin_only", "is_enabled",
+})
+
+
+class ModelPresetRepository:
+    """Repository for model preset CRUD operations."""
+
+    def __init__(self, database):
+        self._db = database
+
+    async def get_all(self) -> List[Dict[str, Any]]:
+        """Get all presets ordered by created_at."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets ORDER BY created_at"
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
+
+    async def get_enabled(self) -> List[Dict[str, Any]]:
+        """Get enabled presets ordered by created_at."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets WHERE is_enabled = 1 ORDER BY created_at"
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
+
+    async def get_available_for_user(self, user_id: int) -> List[Dict[str, Any]]:
+        """Get enabled presets available to a specific user.
+
+        Admin-only presets are included only when user_id belongs to an admin.
+        """
+        from src.utils.admin_utils import is_admin
+
+        presets = await self.get_enabled()
+        if is_admin(user_id):
+            return presets
+        return [p for p in presets if not p.get("admin_only")]
+
+    async def get_by_key(self, key: str) -> Optional[Dict[str, Any]]:
+        """Get a single preset by its unique key."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM model_presets WHERE key = ?",
+                (key,),
+            )
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def upsert(
+        self,
+        key: str,
+        name: str,
+        model: str,
+        base_url: str,
+        api_key: Optional[str] = None,
+        admin_only: bool = False,
+    ) -> None:
+        """Insert or update a preset by key.
+
+        When api_key is None the existing value is preserved via COALESCE.
+        """
+        async with aiosqlite.connect(self._db.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO model_presets (key, name, model, base_url, api_key, admin_only)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    name = excluded.name,
+                    model = excluded.model,
+                    base_url = excluded.base_url,
+                    api_key = COALESCE(excluded.api_key, model_presets.api_key),
+                    admin_only = excluded.admin_only
+                """,
+                (key, name, model, base_url, api_key, int(admin_only)),
+            )
+            await db.commit()
+
+    async def update_field(self, key: str, field: str, value: Any) -> bool:
+        """Update a single field for a preset identified by key.
+
+        Returns True when a row was affected.
+        Raises ValueError if the field name is not in the whitelist.
+        """
+        if field not in _ALLOWED_FIELDS:
+            raise ValueError(
+                f"Field '{field}' is not allowed. "
+                f"Allowed fields: {', '.join(sorted(_ALLOWED_FIELDS))}"
+            )
+
+        async with aiosqlite.connect(self._db.db_path) as db:
+            cursor = await db.execute(
+                f"UPDATE model_presets SET {field} = ? WHERE key = ?",
+                (value, key),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def delete(self, key: str) -> bool:
+        """Delete a preset by key. Returns True if a row was deleted."""
+        async with aiosqlite.connect(self._db.db_path) as db:
+            cursor = await db.execute(
+                "DELETE FROM model_presets WHERE key = ?",
+                (key,),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def sync_from_config(self) -> int:
+        """Import presets from settings.openai_models into DB via upsert.
+
+        Returns the number of presets synced.
+        """
+        from src.config import settings
+
+        fallback_base_url = settings.openai_base_url or "https://api.openai.com/v1"
+        count = 0
+
+        for preset in settings.openai_models:
+            base_url = preset.base_url or fallback_base_url
+            await self.upsert(
+                key=preset.key,
+                name=preset.name,
+                model=preset.model,
+                base_url=base_url,
+            )
+            count += 1
+
+        if count:
+            logger.info(f"Synced {count} model preset(s) from config")
+
+        return count

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -904,12 +904,14 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
             )
             return
 
-        pattern = r'(\S+)\s+"([^"]+)"\s+(\S+)(?:\s+(\S+))?'
-        match = re.match(pattern, args_str)
+        # Support both: /add_model id "Name" url  AND  /add_model id Name url
+        pattern_quoted = r'(\S+)\s+"([^"]+)"\s+(\S+)(?:\s+(\S+))?'
+        pattern_simple = r'(\S+)\s+(\S+)\s+(https?://\S+)(?:\s+(\S+))?'
+        match = re.match(pattern_quoted, args_str) or re.match(pattern_simple, args_str)
         if not match:
             await message.answer(
                 "❌ Неверный формат. Используйте:\n"
-                "`/add_model model_id \"Название\" base_url [api_key]`",
+                "`/add_model model_id Название base_url [api_key]`",
                 parse_mode="Markdown",
             )
             return

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -312,6 +312,10 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
 • `/reset_reliability` - сброс компонентов надежности
 • `/transcription_mode` - переключение режима транскрипции
 
+**Управление моделями:**
+• `/models` - список моделей с inline-управлением
+• `/add_model` - добавить модель
+
 **Очистка файлов:**
 • `/cleanup` - статистика файлов и настройки очистки
 • `/cleanup_force` - принудительная очистка всех временных файлов
@@ -321,9 +325,9 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
 
 **Примечание:** Административные команды доступны только авторизованным пользователям.
         """
-        
+
         await message.answer(help_text, parse_mode="Markdown")
-    
+
     @router.message(Command("performance"))
     async def performance_handler(message: Message):
         """Обработчик команды /performance - статистика производительности"""
@@ -769,6 +773,10 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
 • `/reset_reliability` - сброс компонентов надежности
 • `/transcription_mode` - переключение режима транскрипции
 
+**Управление моделями:**
+• `/models` - список моделей с inline-управлением
+• `/add_model` - добавить модель
+
 **Очистка файлов:**
 • `/cleanup` - статистика файлов и настройки очистки
 • `/cleanup_force` - принудительная очистка всех временных файлов
@@ -778,7 +786,7 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
 
 **Примечание:** Административные команды доступны только авторизованным пользователям.
         """
-        
+
         await safe_edit_text(callback.message, help_text, parse_mode="Markdown")
     
     @router.callback_query(F.data == "admin_back_to_main")
@@ -787,18 +795,321 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
         if not is_admin(callback.from_user.id):
             await callback.answer("❌ Недостаточно прав", show_alert=True)
             return
-        
+
         await callback.answer()
-        
+
         from src.ux.quick_actions import QuickActionsUI
-        
+
         # Показываем меню администратора заново
         keyboard = QuickActionsUI.create_admin_menu()
-        await safe_edit_text(callback.message, 
+        await safe_edit_text(callback.message,
             "🔧 **Меню администратора**\n\n"
             "Выберите действие:",
             reply_markup=keyboard,
             parse_mode="Markdown"
         )
-    
+
+    # ============================================================================
+    # Управление моделями — /add_model, /models и inline-обработчики
+    # ============================================================================
+
+    async def _render_models_list(presets):
+        """Build text and keyboard for the models list view."""
+        if not presets:
+            text = "📋 **Список моделей**\n\nМоделей пока нет. Используйте /add\\_model или синхронизируйте из .env."
+            keyboard = InlineKeyboardMarkup(inline_keyboard=[
+                [InlineKeyboardButton(
+                    text="🔄 Синхр. из .env",
+                    callback_data="admin_models_sync",
+                )],
+            ])
+            return text, keyboard
+
+        lines = ["📋 **Список моделей**\n"]
+        buttons = []
+        for p in presets:
+            if not p.get("is_enabled"):
+                icon = "⛔"
+            elif p.get("admin_only"):
+                icon = "🔒"
+            else:
+                icon = "✅"
+            lines.append(f"{icon} {p['name']}")
+            buttons.append([InlineKeyboardButton(
+                text=f"{icon} {p['name']}",
+                callback_data=f"admin_model_{p['key']}",
+            )])
+
+        buttons.append([InlineKeyboardButton(
+            text="🔄 Синхр. из .env",
+            callback_data="admin_models_sync",
+        )])
+        keyboard = InlineKeyboardMarkup(inline_keyboard=buttons)
+        text = "\n".join(lines)
+        return text, keyboard
+
+    async def _render_model_detail(preset):
+        """Build text and keyboard for a single model detail card."""
+        key = preset["key"]
+        api_key_status = "✅ задан" if preset.get("api_key") else "❌ не задан"
+        enabled_label = "✅ включена" if preset.get("is_enabled") else "⛔ выключена"
+        access_label = "🔒 только админы" if preset.get("admin_only") else "👥 все пользователи"
+
+        text = (
+            f"🤖 **{preset['name']}**\n\n"
+            f"**Key:** `{key}`\n"
+            f"**Model ID:** `{preset['model']}`\n"
+            f"**Base URL:** `{preset['base_url']}`\n"
+            f"**API Key:** {api_key_status}\n"
+            f"**Статус:** {enabled_label}\n"
+            f"**Доступ:** {access_label}"
+        )
+
+        toggle_text = "⛔ Выключить" if preset.get("is_enabled") else "✅ Включить"
+        access_text = "👥 Для всех" if preset.get("admin_only") else "🔒 Только админы"
+
+        keyboard = InlineKeyboardMarkup(inline_keyboard=[
+            [
+                InlineKeyboardButton(text=toggle_text, callback_data=f"admin_model_toggle_{key}"),
+                InlineKeyboardButton(text=access_text, callback_data=f"admin_model_access_{key}"),
+            ],
+            [
+                InlineKeyboardButton(text="🗑 Удалить", callback_data=f"admin_model_delete_{key}"),
+                InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_models_list"),
+            ],
+        ])
+        return text, keyboard
+
+    @router.message(Command("add_model"))
+    async def add_model_handler(message: Message):
+        """Добавление модели: /add_model model_id \"Name\" base_url [api_key]"""
+        if not is_admin(message.from_user.id):
+            await message.answer("❌ Недостаточно прав для выполнения команды.")
+            return
+
+        import re
+        from database import db
+        from src.database.model_preset_repo import ModelPresetRepository
+
+        raw_args = (message.text or "").split(maxsplit=1)
+        args_str = raw_args[1].strip() if len(raw_args) > 1 else ""
+
+        if not args_str:
+            await message.answer(
+                "📖 **Использование:**\n"
+                "`/add_model model_id \"Название\" base_url [api_key]`\n\n"
+                "**Пример:**\n"
+                '`/add_model gpt-4o "GPT-4o" https://api.openai.com/v1 sk-xxx`',
+                parse_mode="Markdown",
+            )
+            return
+
+        pattern = r'(\S+)\s+"([^"]+)"\s+(\S+)(?:\s+(\S+))?'
+        match = re.match(pattern, args_str)
+        if not match:
+            await message.answer(
+                "❌ Неверный формат. Используйте:\n"
+                "`/add_model model_id \"Название\" base_url [api_key]`",
+                parse_mode="Markdown",
+            )
+            return
+
+        model_id = match.group(1)
+        name = match.group(2)
+        base_url = match.group(3)
+        api_key = match.group(4)  # may be None
+
+        key = re.sub(r'[^a-zA-Z0-9_-]', '_', model_id)
+
+        try:
+            repo = ModelPresetRepository(db)
+            await repo.upsert(key, name, model_id, base_url, api_key)
+
+            api_display = "задан" if api_key else "не задан (используется существующий)"
+            await message.answer(
+                f"✅ Модель добавлена/обновлена\n\n"
+                f"**Key:** `{key}`\n"
+                f"**Название:** {name}\n"
+                f"**Model ID:** `{model_id}`\n"
+                f"**Base URL:** `{base_url}`\n"
+                f"**API Key:** {api_display}",
+                parse_mode="Markdown",
+            )
+        except Exception as e:
+            logger.error(f"Ошибка в add_model_handler: {e}")
+            await message.answer(f"❌ Ошибка при добавлении модели: {e}")
+
+    @router.message(Command("models"))
+    async def models_handler(message: Message):
+        """Список всех моделей с inline-кнопками."""
+        if not is_admin(message.from_user.id):
+            await message.answer("❌ Недостаточно прав для выполнения команды.")
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            repo = ModelPresetRepository(db)
+            presets = await repo.get_all()
+            text, keyboard = await _render_models_list(presets)
+            await message.answer(text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в models_handler: {e}")
+            await message.answer(f"❌ Ошибка при получении списка моделей: {e}")
+
+    @router.callback_query(F.data.startswith("admin_model_toggle_"))
+    async def admin_model_toggle_callback(callback: CallbackQuery):
+        """Переключить is_enabled для модели."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            key = callback.data.replace("admin_model_toggle_", "", 1)
+            repo = ModelPresetRepository(db)
+            preset = await repo.get_by_key(key)
+            if not preset:
+                await safe_edit_text(callback.message, f"❌ Модель `{key}` не найдена.", parse_mode="Markdown")
+                return
+
+            new_value = 0 if preset.get("is_enabled") else 1
+            await repo.update_field(key, "is_enabled", new_value)
+
+            updated = await repo.get_by_key(key)
+            text, keyboard = await _render_model_detail(updated)
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_model_toggle_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка: {e}")
+
+    @router.callback_query(F.data.startswith("admin_model_access_"))
+    async def admin_model_access_callback(callback: CallbackQuery):
+        """Переключить admin_only для модели."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            key = callback.data.replace("admin_model_access_", "", 1)
+            repo = ModelPresetRepository(db)
+            preset = await repo.get_by_key(key)
+            if not preset:
+                await safe_edit_text(callback.message, f"❌ Модель `{key}` не найдена.", parse_mode="Markdown")
+                return
+
+            new_value = 0 if preset.get("admin_only") else 1
+            await repo.update_field(key, "admin_only", new_value)
+
+            updated = await repo.get_by_key(key)
+            text, keyboard = await _render_model_detail(updated)
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_model_access_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка: {e}")
+
+    @router.callback_query(F.data.startswith("admin_model_delete_"))
+    async def admin_model_delete_callback(callback: CallbackQuery):
+        """Удалить модель и вернуться к списку."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            key = callback.data.replace("admin_model_delete_", "", 1)
+            repo = ModelPresetRepository(db)
+            deleted = await repo.delete(key)
+
+            if not deleted:
+                await safe_edit_text(callback.message, f"❌ Модель `{key}` не найдена.", parse_mode="Markdown")
+                return
+
+            presets = await repo.get_all()
+            text, keyboard = await _render_models_list(presets)
+            text = f"🗑 Модель `{key}` удалена.\n\n{text}"
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_model_delete_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка: {e}")
+
+    @router.callback_query(F.data.startswith("admin_model_"))
+    async def admin_model_detail_callback(callback: CallbackQuery):
+        """Карточка модели (детальный просмотр)."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            key = callback.data.replace("admin_model_", "", 1)
+            repo = ModelPresetRepository(db)
+            preset = await repo.get_by_key(key)
+            if not preset:
+                await safe_edit_text(callback.message, f"❌ Модель `{key}` не найдена.", parse_mode="Markdown")
+                return
+
+            text, keyboard = await _render_model_detail(preset)
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_model_detail_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка: {e}")
+
+    @router.callback_query(F.data == "admin_models_sync")
+    async def admin_models_sync_callback(callback: CallbackQuery):
+        """Синхронизировать модели из .env конфига."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            repo = ModelPresetRepository(db)
+            count = await repo.sync_from_config()
+
+            presets = await repo.get_all()
+            text, keyboard = await _render_models_list(presets)
+            text = f"🔄 Синхронизировано моделей: {count}\n\n{text}"
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_models_sync_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка синхронизации: {e}")
+
+    @router.callback_query(F.data == "admin_models_list")
+    async def admin_models_list_callback(callback: CallbackQuery):
+        """Вернуться к списку моделей (inline)."""
+        if not is_admin(callback.from_user.id):
+            await callback.answer("❌ Недостаточно прав", show_alert=True)
+            return
+
+        try:
+            from database import db
+            from src.database.model_preset_repo import ModelPresetRepository
+
+            await callback.answer()
+            repo = ModelPresetRepository(db)
+            presets = await repo.get_all()
+            text, keyboard = await _render_models_list(presets)
+            await safe_edit_text(callback.message, text, reply_markup=keyboard, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Ошибка в admin_models_list_callback: {e}")
+            await safe_edit_text(callback.message, f"❌ Ошибка: {e}")
+
     return router

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -919,7 +919,16 @@ def setup_admin_handlers(llm_service: EnhancedLLMService,
         base_url = match.group(3)
         api_key = match.group(4)  # may be None
 
+        # Валидация base_url
+        from urllib.parse import urlparse
+        parsed = urlparse(base_url)
+        if parsed.scheme not in ('https', 'http'):
+            await message.answer("❌ base_url должен начинаться с https:// или http://")
+            return
+
         key = re.sub(r'[^a-zA-Z0-9_-]', '_', model_id)
+        if len(key) > 40:
+            key = key[:40]
 
         try:
             repo = ModelPresetRepository(db)

--- a/src/handlers/callbacks/settings_callbacks.py
+++ b/src/handlers/callbacks/settings_callbacks.py
@@ -93,15 +93,22 @@ def setup_settings_callbacks(user_service: UserService, template_service: Templa
         """Устанавливает предпочитаемую модель OpenAI"""
         try:
             model_key = callback.data.replace("set_openai_model_", "")
+
+            # Проверяем, что модель доступна этому пользователю (защита от IDOR)
+            from src.database.model_preset_repo import ModelPresetRepository
+            from database import db as app_db
+            repo = ModelPresetRepository(app_db)
+            allowed = await repo.get_available_for_user(callback.from_user.id)
+            if not any(p['key'] == model_key for p in allowed):
+                await callback.answer("❌ Модель недоступна", show_alert=True)
+                return
+
             await user_service.update_user_openai_model_preference(callback.from_user.id, model_key)
-            # Находим человекочитаемое имя модели из БД
             try:
-                from src.database.model_preset_repo import ModelPresetRepository
-                from database import db as app_db
-                repo = ModelPresetRepository(app_db)
                 preset = await repo.get_by_key(model_key)
                 model_name = preset['name'] if preset else model_key
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Не удалось получить название модели {model_key}: {e}")
                 model_name = model_key
             await safe_edit_text(callback.message,
                 f"✅ Модель OpenAI обновлена: {model_name}.\n\n"

--- a/src/handlers/callbacks/settings_callbacks.py
+++ b/src/handlers/callbacks/settings_callbacks.py
@@ -53,12 +53,14 @@ def setup_settings_callbacks(user_service: UserService, template_service: Templa
     async def settings_openai_model_callback(callback: CallbackQuery):
         """Обработчик меню выбора модели OpenAI"""
         try:
-            from config import settings as app_settings
-            models = getattr(app_settings, 'openai_models', [])
-            if not models or len(models) == 0:
+            from src.database.model_preset_repo import ModelPresetRepository
+            from database import db as app_db
+            repo = ModelPresetRepository(app_db)
+            presets = await repo.get_available_for_user(callback.from_user.id)
+            if not presets:
                 await safe_edit_text(callback.message,
-                    "❌ Не настроены модели OpenAI.\n\n"
-                    "Добавьте переменную окружения `OPENAI_MODELS` с перечнем пресетов.",
+                    "❌ Нет доступных моделей.\n\n"
+                    "Используйте /add_model чтобы добавить модель.",
                     reply_markup=InlineKeyboardMarkup(inline_keyboard=[
                         [InlineKeyboardButton(text="⬅️ Назад к настройкам", callback_data="back_to_settings")]
                     ])
@@ -70,9 +72,9 @@ def setup_settings_callbacks(user_service: UserService, template_service: Templa
             selected_key = getattr(user, 'preferred_openai_model_key', None) if user else None
 
             keyboard_rows = []
-            for p in models:
-                label = f"{'✅ ' if selected_key == p.key else ''}{p.name}"
-                keyboard_rows.append([InlineKeyboardButton(text=label, callback_data=f"set_openai_model_{p.key}")])
+            for p in presets:
+                label = f"{'✅ ' if selected_key == p['key'] else ''}{p['name']}"
+                keyboard_rows.append([InlineKeyboardButton(text=label, callback_data=f"set_openai_model_{p['key']}")])
             keyboard_rows.append([InlineKeyboardButton(text="🔄 Сбросить выбор модели", callback_data="reset_openai_model_preference")])
             keyboard_rows.append([InlineKeyboardButton(text="⬅️ Назад к настройкам", callback_data="back_to_settings")])
 
@@ -92,11 +94,13 @@ def setup_settings_callbacks(user_service: UserService, template_service: Templa
         try:
             model_key = callback.data.replace("set_openai_model_", "")
             await user_service.update_user_openai_model_preference(callback.from_user.id, model_key)
-            # Находим человекочитаемое имя модели из настроек
+            # Находим человекочитаемое имя модели из БД
             try:
-                from config import settings as app_settings
-                preset = next((p for p in getattr(app_settings, 'openai_models', []) if p.key == model_key), None)
-                model_name = preset.name if preset else model_key
+                from src.database.model_preset_repo import ModelPresetRepository
+                from database import db as app_db
+                repo = ModelPresetRepository(app_db)
+                preset = await repo.get_by_key(model_key)
+                model_name = preset['name'] if preset else model_key
             except Exception:
                 model_name = model_key
             await safe_edit_text(callback.message,

--- a/src/llm/providers/openai_provider.py
+++ b/src/llm/providers/openai_provider.py
@@ -22,19 +22,41 @@ class OpenAIProvider(LLMProvider):
     """Provider for OpenAI GPT."""
 
     def __init__(self):
-        self.client = None
+        self.default_client = None
         self.http_client = None
+        self._client_cache = {}
         if settings.openai_api_key:
             openai.api_key = settings.openai_api_key
             self.http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
-            self.client = openai.OpenAI(
+            self.default_client = openai.OpenAI(
                 api_key=settings.openai_api_key,
                 base_url=settings.openai_base_url,
                 http_client=self.http_client
             )
 
+    def _get_client(self, preset: dict = None):
+        """Get or create an OpenAI client for the given preset."""
+        if not preset:
+            return self.default_client
+
+        base_url = preset.get('base_url') or settings.openai_base_url
+        api_key = preset.get('api_key') or settings.openai_api_key
+
+        cache_key = (base_url, hash(api_key) if api_key else None)
+
+        if cache_key not in self._client_cache:
+            http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
+            self._client_cache[cache_key] = openai.OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=http_client,
+            )
+            logger.info(f"Создан клиент для {base_url}")
+
+        return self._client_cache[cache_key]
+
     def is_available(self) -> bool:
-        return self.client is not None and settings.openai_api_key is not None
+        return self.default_client is not None and settings.openai_api_key is not None
 
     async def generate_protocol(self, transcription: str, template_variables: Dict[str, str],
                                 diarization_data: Optional[Dict[str, Any]] = None, **kwargs) -> Dict[str, Any]:
@@ -66,13 +88,24 @@ class OpenAIProvider(LLMProvider):
 
         selected_model = settings.openai_model
         openai_model_key = kwargs.get('openai_model_key')
+        preset_dict = None
 
         if openai_model_key:
             try:
-                preset = next((p for p in settings.openai_models if p.key == openai_model_key), None)
-                if preset:
-                    selected_model = preset.model
-                    logger.info(f"Используется пользовательская модель: {selected_model} (ключ: {openai_model_key})")
+                from src.database.model_preset_repo import ModelPresetRepository
+                from src.database import db
+                repo = ModelPresetRepository(db)
+                preset_dict = await repo.get_by_key(openai_model_key)
+
+                if preset_dict:
+                    selected_model = preset_dict['model']
+                    logger.info(f"Используется модель из БД: {selected_model} (ключ: {openai_model_key})")
+                else:
+                    preset = next((p for p in settings.openai_models if p.key == openai_model_key), None)
+                    if preset:
+                        selected_model = preset.model
+                        preset_dict = {'base_url': preset.base_url, 'api_key': None}
+                        logger.info(f"Используется модель из конфига: {selected_model} (ключ: {openai_model_key})")
             except Exception as e:
                 logger.warning(f"Не удалось определить модель по ключу {openai_model_key}: {e}")
 
@@ -109,6 +142,8 @@ class OpenAIProvider(LLMProvider):
         # Stage 2: Generation
         logger.info("Запуск ЭТАПА 2: Генерация протокола")
 
+        client = self._get_client(preset_dict)
+
         generation_system_prompt = build_generation_system_prompt(template_variables=template_variables)
         generation_user_prompt = build_generation_prompt(
             transcription=analysis_transcription,
@@ -124,7 +159,8 @@ class OpenAIProvider(LLMProvider):
             user_prompt=generation_user_prompt,
             schema=PROTOCOL_DATA_SCHEMA,
             step_name="Generation",
-            model=selected_model
+            model=selected_model,
+            client=client
         )
 
         protocol_data = generation_result.get('protocol_data', {})
@@ -139,9 +175,10 @@ class OpenAIProvider(LLMProvider):
         return final_result
 
     async def _call_openai(self, system_prompt: str, user_prompt: str, schema: Dict[str, Any],
-                           step_name: str, model: str = None) -> Dict[str, Any]:
+                           step_name: str, model: str = None, client=None) -> Dict[str, Any]:
         """Helper method for OpenAI API calls."""
         selected_model = model or settings.openai_model
+        active_client = client or self.default_client
 
         extra_headers = {}
         if settings.http_referer:
@@ -153,7 +190,7 @@ class OpenAIProvider(LLMProvider):
 
         async def _api_call():
             return await asyncio.to_thread(
-                self.client.chat.completions.create,
+                active_client.chat.completions.create,
                 model=selected_model,
                 messages=[
                     {"role": "system", "content": system_prompt},

--- a/src/llm/providers/openai_provider.py
+++ b/src/llm/providers/openai_provider.py
@@ -25,9 +25,11 @@ class OpenAIProvider(LLMProvider):
         self.default_client = None
         self.http_client = None
         self._client_cache = {}
+        self._http_clients = []  # track for cleanup
         if settings.openai_api_key:
             openai.api_key = settings.openai_api_key
             self.http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
+            self._http_clients.append(self.http_client)
             self.default_client = openai.OpenAI(
                 api_key=settings.openai_api_key,
                 base_url=settings.openai_base_url,
@@ -46,6 +48,7 @@ class OpenAIProvider(LLMProvider):
 
         if cache_key not in self._client_cache:
             http_client = httpx.Client(verify=settings.ssl_verify, timeout=settings.llm_timeout_seconds)
+            self._http_clients.append(http_client)
             self._client_cache[cache_key] = openai.OpenAI(
                 api_key=api_key,
                 base_url=base_url,
@@ -54,6 +57,16 @@ class OpenAIProvider(LLMProvider):
             logger.info(f"Создан клиент для {base_url}")
 
         return self._client_cache[cache_key]
+
+    def close(self):
+        """Close all cached HTTP clients."""
+        for client in self._http_clients:
+            try:
+                client.close()
+            except Exception:
+                pass
+        self._http_clients.clear()
+        self._client_cache.clear()
 
     def is_available(self) -> bool:
         return self.default_client is not None and settings.openai_api_key is not None

--- a/src/services/processing/llm_generation.py
+++ b/src/services/processing/llm_generation.py
@@ -78,7 +78,7 @@ class LLMGenerationService:
                 openai_model_key = None
 
             # Определяем название используемой модели
-            llm_model_name = self.get_model_display_name(request.llm_provider, openai_model_key)  # noqa: F841
+            llm_model_name = await self.get_model_display_name(request.llm_provider, openai_model_key)  # noqa: F841
 
             # Извлекаем анализ диаризации если есть
             diarization_analysis = None
@@ -319,21 +319,34 @@ class LLMGenerationService:
                 'next_sprint_plans': '',
             }
 
-    def get_model_display_name(
+    async def get_model_display_name(
         self, provider: str, openai_model_key: Optional[str] = None
     ) -> str:
         """Получить читаемое название модели"""
+        if provider == "openai" and openai_model_key:
+            # Try DB first
+            try:
+                from src.database.model_preset_repo import ModelPresetRepository
+                from database import db
+                repo = ModelPresetRepository(db)
+                preset = await repo.get_by_key(openai_model_key)
+                if preset:
+                    return preset['name']
+            except Exception:
+                pass
+
+            # Fallback to config
+            try:
+                preset = next(
+                    (p for p in settings.openai_models if p.key == openai_model_key),
+                    None,
+                )
+                if preset:
+                    return preset.name
+            except Exception:
+                pass
+
         if provider == "openai":
-            if openai_model_key:
-                try:
-                    preset = next(
-                        (p for p in settings.openai_models if p.key == openai_model_key),
-                        None,
-                    )
-                    if preset:
-                        return preset.name
-                except Exception:
-                    pass
             return settings.openai_model or "GPT-4o"
 
         return provider.capitalize()

--- a/src/services/processing/processing_service.py
+++ b/src/services/processing/processing_service.py
@@ -108,8 +108,8 @@ class ProcessingService(BaseProcessingService):
     def _get_template_variables_from_template(self, template):
         return self.llm_gen.get_template_variables_from_template(template)
 
-    def _get_model_display_name(self, provider, openai_model_key=None):
-        return self.llm_gen.get_model_display_name(provider, openai_model_key)
+    async def _get_model_display_name(self, provider, openai_model_key=None):
+        return await self.llm_gen.get_model_display_name(provider, openai_model_key)
 
     async def _generate_llm_response(self, *args, **kwargs):
         return await self.llm_gen.generate_llm_response(*args, **kwargs)
@@ -402,7 +402,7 @@ class ProcessingService(BaseProcessingService):
             openai_model_key = None
             if request.llm_provider == 'openai':
                 openai_model_key = getattr(user, 'preferred_openai_model_key', None)
-            llm_model_display_name = self._get_model_display_name(
+            llm_model_display_name = await self._get_model_display_name(
                 request.llm_provider, openai_model_key
             )
 
@@ -744,7 +744,7 @@ class ProcessingService(BaseProcessingService):
             openai_model_key = None
             if request.llm_provider == 'openai' and user:
                 openai_model_key = getattr(user, 'preferred_openai_model_key', None)
-            llm_model_display_name = self._get_model_display_name(
+            llm_model_display_name = await self._get_model_display_name(
                 request.llm_provider, openai_model_key
             )
 


### PR DESCRIPTION
## Summary

- **model_presets DB table** — persistent storage for model configurations with access control
- **Admin commands** — `/add_model` (quick add) and `/models` (inline UI for list/edit/delete/toggle)
- **Per-preset API clients** — each model can have its own `base_url` and `api_key` (OpenRouter, local servers, etc.)
- **Access control** — models can be restricted to admins only, enabled/disabled
- **Settings UI** — user model selection now reads from DB with access filtering
- **.env sync** — existing `OPENAI_MODELS` presets auto-imported into DB on startup

## Test Plan

- [ ] Bot starts, syncs presets from .env into DB
- [ ] `/add_model google/gemini-2.0-flash gemma https://openrouter.ai/api/v1` — adds model
- [ ] `/models` — shows list with inline buttons
- [ ] Toggle enable/disable, admin-only access, delete via inline UI
- [ ] User settings shows only available models (respects admin_only + is_enabled)
- [ ] Processing uses correct base_url/api_key per preset
- [ ] "Sync from .env" button re-imports config presets