### PR TITLE
fix: restore speaker↔participant mapping UI (strict-schema 400 + loud failure)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-speaker-mapping-strict-schema-fix.md
+++ b/docs/superpowers/plans/2026-06-08-speaker-mapping-strict-schema-fix.md
@@ -1,0 +1,472 @@
+# Speaker-Mapping Strict-Schema Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the speaker↔participant confirmation UI by making `SpeakerMappingSchema` valid for OpenAI strict Structured Outputs, hardening the schema generator against the whole class of bug, and making a hard LLM-mapping failure loud instead of silent.
+
+**Architecture:** Three coupled changes. (1) Add `extra="forbid"` to `SpeakerMappingSchema` so Pydantic emits `additionalProperties: false` at the schema root. (2) Add a recursive pass in `get_json_schema` that locks down every object node for strict mode, without clobbering typed `Dict` maps. (3) Convert the silent `return {}` on a hard LLM call error into a typed `SpeakerMappingLLMError` that `map_speakers_to_participants` logs with a greppable marker and degrades gracefully.
+
+**Tech Stack:** Python 3, Pydantic v2 (2.12.5), pytest (`asyncio_mode = "auto"`), loguru, ruff. Tests run with the project venv at `.venv/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-speaker-mapping-strict-schema-fix-design.md`
+
+---
+
+## File Structure
+
+- `src/models/llm_schemas.py` — **modify**. Add `Config: extra = "forbid"` to `SpeakerMappingSchema` (~line 100); add `enforce_additional_properties_false` pass inside `get_json_schema` (function at lines 145-212).
+- `src/services/speaker_mapping_service.py` — **modify**. Add `SpeakerMappingLLMError` (module top, after imports ~line 14); raise it from the two silent-`return {}` points in `_call_llm_for_mapping` (JSON-parse path ~577-581, generic `except` ~600-602); add a dedicated `except SpeakerMappingLLMError` branch in `map_speakers_to_participants` (~before line 91).
+- `tests/test_llm_schemas_strict.py` — **create**. Strict-compliance schema tests (Parts 1 & 2).
+- `tests/test_speaker_mapping_failure.py` — **create**. Loud-failure behaviour test (Part 3).
+
+All test commands assume the project venv. Either activate it (`source .venv/bin/activate`) or prefix with `.venv/bin/`. This plan uses the `.venv/bin/` prefix form.
+
+---
+
+## Task 1: Strict-schema compliance (Parts 1 & 2)
+
+**Files:**
+- Modify: `src/models/llm_schemas.py` (`SpeakerMappingSchema` ~line 100; `get_json_schema` lines 145-212)
+- Test: `tests/test_llm_schemas_strict.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_schemas_strict.py`:
+
+```python
+"""Strict Structured Outputs schema compliance.
+
+OpenAI/Azure strict mode requires `additionalProperties: false` on every object
+schema node (including the root) whenever `strict: true` is sent. SpeakerMappingSchema
+historically lacked this at the root, which made the speaker-mapping LLM call fail
+with HTTP 400 and silently disabled the speaker-mapping confirmation UI.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _all_predefined_schemas():
+    from src.models import llm_schemas
+
+    names = [n for n in dir(llm_schemas) if n.endswith("_SCHEMA")]
+    return [(n, getattr(llm_schemas, n)) for n in names]
+
+
+def test_speaker_mapping_schema_root_is_closed():
+    from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA
+
+    assert SPEAKER_MAPPING_SCHEMA["strict"] is True
+    assert SPEAKER_MAPPING_SCHEMA["schema"].get("additionalProperties") is False
+
+
+@pytest.mark.parametrize("name,schema", _all_predefined_schemas())
+def test_all_strict_schema_roots_are_closed(name, schema):
+    if schema.get("strict") is True:
+        root = schema["schema"]
+        assert root.get("additionalProperties") is False, (
+            f"{name}: strict schema root must set additionalProperties=false"
+        )
+
+
+def test_dict_fields_keep_typed_additional_properties():
+    """Dict[str, T] maps must keep their typed additionalProperties, NOT be
+    overwritten with false (that would forbid the dynamic keys the LLM fills)."""
+    from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA
+
+    props = SPEAKER_MAPPING_SCHEMA["schema"]["properties"]
+    for field in ("speaker_mappings", "confidence_scores"):
+        ap = props[field].get("additionalProperties")
+        assert isinstance(ap, dict), f"{field} should keep a typed additionalProperties"
+        assert ap is not False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_llm_schemas_strict.py -v`
+Expected: `test_speaker_mapping_schema_root_is_closed` FAILS (root `additionalProperties` is missing → `None is False` → AssertionError); the parametrized case for `SPEAKER_MAPPING_SCHEMA` FAILS for the same reason. The `test_dict_fields_keep_typed_additional_properties` test PASSES already (Dict fields are untouched today).
+
+- [ ] **Step 3: Implement Part 1 — close the SpeakerMappingSchema root**
+
+In `src/models/llm_schemas.py`, add a `Config` to `SpeakerMappingSchema`. The class currently ends at the `mapping_notes` field:
+
+```python
+    unmapped_speakers: List[str] = Field(
+        description="Список speaker_id (например, SPEAKER_3) с уверенностью < 0.7, которых не удалось надежно сопоставить с участниками"
+    )
+    mapping_notes: str = Field(description="Заметки по сопоставлению и определению типа встречи")
+
+    class Config:
+        extra = "forbid"
+```
+
+(Add the `class Config: extra = "forbid"` block immediately after the `mapping_notes` field, matching every other schema in this module.)
+
+- [ ] **Step 4: Implement Part 2 — harden `get_json_schema`**
+
+In `src/models/llm_schemas.py`, inside `get_json_schema`, the body currently ends:
+
+```python
+    fix_required_fields(schema)
+
+    # OpenAI требует определенный формат
+    return {
+        "name": schema.get("title", model_class.__name__),
+        "schema": schema,
+        "strict": True
+    }
+```
+
+Replace that tail with a recursive lock-down pass added before the return:
+
+```python
+    def enforce_additional_properties_false(node: Dict[str, Any]) -> None:
+        """Strict Structured Outputs требует additionalProperties:false на КАЖДОМ
+        объектном узле (включая корень). Проставляем его рекурсивно, НЕ трогая
+        узлы, где additionalProperties уже задан — это типизированные Dict-карты
+        вида {"additionalProperties": {"type": "string"}}, которые провайдер
+        принимает и которые нужны для динамических ключей.
+        """
+        if not isinstance(node, dict):
+            return
+
+        if node.get("type") == "object" and "additionalProperties" not in node:
+            node["additionalProperties"] = False
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for child in properties.values():
+                enforce_additional_properties_false(child)
+
+        defs = node.get("$defs")
+        if isinstance(defs, dict):
+            for child in defs.values():
+                enforce_additional_properties_false(child)
+
+        items = node.get("items")
+        if isinstance(items, dict):
+            enforce_additional_properties_false(items)
+
+    fix_required_fields(schema)
+    enforce_additional_properties_false(schema)
+
+    # OpenAI требует определенный формат
+    return {
+        "name": schema.get("title", model_class.__name__),
+        "schema": schema,
+        "strict": True
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_llm_schemas_strict.py -v`
+Expected: all tests PASS (root `additionalProperties` is now `False` for `SPEAKER_MAPPING_SCHEMA` and every strict schema; Dict fields still carry typed `additionalProperties`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/llm_schemas.py tests/test_llm_schemas_strict.py
+git commit -m "fix(schemas): close SpeakerMappingSchema root for strict Structured Outputs
+
+SpeakerMappingSchema was the only schema without extra=forbid, so its
+strict response_format lacked additionalProperties:false at the root and
+OpenAI rejected the mapping call with HTTP 400 — silently disabling the
+speaker-mapping confirmation UI. Add the Config and harden get_json_schema
+to enforce additionalProperties:false on every object node (without
+clobbering typed Dict maps), so no future strict schema can regress."
+```
+
+---
+
+## Task 2: Loud failure on LLM mapping error (Part 3)
+
+**Files:**
+- Modify: `src/services/speaker_mapping_service.py` (exception class ~line 14; `_call_llm_for_mapping` ~577-581 and ~600-602; `map_speakers_to_participants` ~before line 91)
+- Test: `tests/test_speaker_mapping_failure.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_speaker_mapping_failure.py`:
+
+```python
+"""The speaker-mapping LLM call must fail LOUDLY, not silently.
+
+A hard LLM/API error (e.g. HTTP 400 invalid schema) must be distinguishable from
+a genuinely-empty mapping. The service raises SpeakerMappingLLMError internally and
+map_speakers_to_participants logs a greppable marker, then degrades to ({}, "general")
+so the protocol still generates.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.mark.asyncio
+async def test_mapping_llm_failure_is_loud_and_degrades(monkeypatch):
+    from loguru import logger
+    from src.services.speaker_mapping_service import (
+        SpeakerMappingService,
+        SpeakerMappingLLMError,
+    )
+
+    service = SpeakerMappingService()
+
+    # Force a non-empty speakers_info so we reach the LLM call, and a trivial prompt.
+    monkeypatch.setattr(
+        service,
+        "_extract_speakers_info",
+        lambda *a, **k: [{"speaker": "SPEAKER_1", "samples": ["привет"]}],
+    )
+    monkeypatch.setattr(service, "_build_mapping_prompt", lambda *a, **k: "prompt")
+
+    async def _raise(*a, **k):
+        raise SpeakerMappingLLMError("HTTP 400 invalid schema")
+
+    monkeypatch.setattr(service, "_call_llm_for_mapping", _raise)
+
+    # Capture loguru ERROR output.
+    records = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        mapping, meeting_type = await service.map_speakers_to_participants(
+            diarization_data={"speakers": ["SPEAKER_1"], "segments": []},
+            participants=[{"name": "Иван Петров", "role": "PM"}],
+            transcription_text="...",
+            llm_provider="openai",
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert mapping == {}
+    assert meeting_type == "general"
+    assert any("SPEAKER_MAPPING_LLM_FAILED" in str(r) for r in records), (
+        "hard LLM failure must be logged with the SPEAKER_MAPPING_LLM_FAILED marker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_mapping_is_not_treated_as_failure(monkeypatch):
+    """A successful call returning no confident matches is NOT a failure: no marker."""
+    from loguru import logger
+    from src.services.speaker_mapping_service import SpeakerMappingService
+
+    service = SpeakerMappingService()
+    monkeypatch.setattr(
+        service,
+        "_extract_speakers_info",
+        lambda *a, **k: [{"speaker": "SPEAKER_1", "samples": ["привет"]}],
+    )
+    monkeypatch.setattr(service, "_build_mapping_prompt", lambda *a, **k: "prompt")
+
+    async def _empty(*a, **k):
+        return {"meeting_type": "business", "speaker_mappings": {}}
+
+    monkeypatch.setattr(service, "_call_llm_for_mapping", _empty)
+
+    records = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        mapping, meeting_type = await service.map_speakers_to_participants(
+            diarization_data={"speakers": ["SPEAKER_1"], "segments": []},
+            participants=[{"name": "Иван Петров", "role": "PM"}],
+            transcription_text="...",
+            llm_provider="openai",
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert mapping == {}
+    assert meeting_type == "business"
+    assert not any("SPEAKER_MAPPING_LLM_FAILED" in str(r) for r in records)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_speaker_mapping_failure.py -v`
+Expected: `test_mapping_llm_failure_is_loud_and_degrades` FAILS at import — `cannot import name 'SpeakerMappingLLMError'` (the exception does not exist yet). The second test cannot run either due to the import in the first test's body, but it targets the same module.
+
+- [ ] **Step 3: Define the typed exception**
+
+In `src/services/speaker_mapping_service.py`, after the imports block (the `from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA` line, ~line 13) and before `class SpeakerMappingService`, add:
+
+```python
+class SpeakerMappingLLMError(Exception):
+    """Жёсткий сбой LLM-вызова сопоставления (ошибка API / схемы / парсинга).
+
+    Отличает реальный сбой вызова от легитимного пустого результата, когда LLM
+    честно вернул отсутствие сопоставлений. Жёсткий сбой логируется громко и
+    приводит к мягкой деградации, а не к молчаливому пустому маппингу.
+    """
+```
+
+- [ ] **Step 4: Raise the exception from the two silent points in `_call_llm_for_mapping`**
+
+In `_call_llm_for_mapping`, the JSON-parse failure currently swallows the error:
+
+```python
+                try:
+                    result = safe_json_parse(content, context="SpeakerMappingService LLM response")
+                except (ValueError, json.JSONDecodeError) as e:
+                    logger.error(f"❌ Не удалось распарсить JSON ответа от LLM для маппинга спикеров: {e}")
+                    return {}
+```
+
+Change the `return {}` to a raise:
+
+```python
+                try:
+                    result = safe_json_parse(content, context="SpeakerMappingService LLM response")
+                except (ValueError, json.JSONDecodeError) as e:
+                    logger.error(f"❌ Не удалось распарсить JSON ответа от LLM для маппинга спикеров: {e}")
+                    raise SpeakerMappingLLMError(f"JSON parse failed: {e}") from e
+```
+
+Then the generic outer handler currently swallows API/schema errors:
+
+```python
+        except Exception as e:
+            logger.error(f"Ошибка при вызове LLM для сопоставления: {e}")
+            return {}
+```
+
+Replace it so a `SpeakerMappingLLMError` propagates unchanged and any other error is wrapped:
+
+```python
+        except SpeakerMappingLLMError:
+            raise
+        except Exception as e:
+            logger.error(f"Ошибка при вызове LLM для сопоставления: {e}")
+            raise SpeakerMappingLLMError(str(e)) from e
+```
+
+Leave the non-openai `else: return {}` branch (~line 594-598) untouched — that is a deliberate "not optimized for this provider" skip, not a failure.
+
+- [ ] **Step 5: Add the dedicated handler in `map_speakers_to_participants`**
+
+The method currently ends with a single generic handler:
+
+```python
+        except Exception as e:
+            logger.error(f"Ошибка при сопоставлении спикеров: {e}")
+            # Возвращаем пустой mapping и general тип
+            return {}, "general"
+```
+
+Insert a dedicated branch BEFORE the generic one (order matters — the specific except must come first):
+
+```python
+        except SpeakerMappingLLMError as e:
+            logger.error(
+                f"SPEAKER_MAPPING_LLM_FAILED provider={llm_provider}: {e}. "
+                "Протокол будет сгенерирован без сопоставления спикеров."
+            )
+            return {}, "general"
+        except Exception as e:
+            logger.error(f"Ошибка при сопоставлении спикеров: {e}")
+            # Возвращаем пустой mapping и general тип
+            return {}, "general"
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_speaker_mapping_failure.py -v`
+Expected: both tests PASS — the hard failure path logs `SPEAKER_MAPPING_LLM_FAILED` and returns `({}, "general")`; the empty-but-successful path returns `({}, "business")` with no marker.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/speaker_mapping_service.py tests/test_speaker_mapping_failure.py
+git commit -m "fix(mapping): fail loudly on LLM mapping error instead of silent {}
+
+A hard LLM/API/parse error in _call_llm_for_mapping used to return {} and be
+indistinguishable from 'no confident matches', so a provider/schema break
+disabled the speaker-mapping feature invisibly. Introduce SpeakerMappingLLMError,
+raise it from both swallow points, and log a greppable SPEAKER_MAPPING_LLM_FAILED
+marker in map_speakers_to_participants before degrading gracefully."
+```
+
+---
+
+## Task 3: Verification gate (full suite + lint + schema sanity)
+
+**Files:** none modified — this task only runs checks.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS, including the pre-existing suite plus the new schema and failure tests. No regressions.
+
+- [ ] **Step 2: Run the linter**
+
+Run: `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
+Expected: clean (no errors). If `ruff format --check` reports the new files need formatting, run `.venv/bin/ruff format src/models/llm_schemas.py src/services/speaker_mapping_service.py tests/test_llm_schemas_strict.py tests/test_speaker_mapping_failure.py` and re-run the check.
+
+- [ ] **Step 3: Local schema sanity check**
+
+Run:
+```bash
+.venv/bin/python -c "
+from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA, PROTOCOL_SCHEMA, MEETING_ANALYSIS_SCHEMA
+for n, s in [('SPEAKER_MAPPING_SCHEMA', SPEAKER_MAPPING_SCHEMA), ('PROTOCOL_SCHEMA', PROTOCOL_SCHEMA), ('MEETING_ANALYSIS_SCHEMA', MEETING_ANALYSIS_SCHEMA)]:
+    print(n, 'root additionalProperties =', s['schema'].get('additionalProperties'), '| strict =', s['strict'])
+"
+```
+Expected output:
+```
+SPEAKER_MAPPING_SCHEMA root additionalProperties = False | strict = True
+PROTOCOL_SCHEMA root additionalProperties = False | strict = True
+MEETING_ANALYSIS_SCHEMA root additionalProperties = False | strict = True
+```
+
+- [ ] **Step 4: Commit (only if Step 2 reformatted files)**
+
+If `ruff format` changed any file in Step 2, commit it:
+```bash
+git add -A
+git commit -m "chore: ruff format for speaker-mapping schema fix"
+```
+Otherwise skip — no commit needed.
+
+---
+
+## Deployment (separate — requires explicit user confirmation)
+
+This is an outward-facing, hard-to-reverse action. Do NOT run it as part of plan execution; confirm with the user first.
+
+1. Merge the branch `fix/speaker-mapping-strict-schema` into `main` (PR or fast-forward, per the user's preference).
+2. On prod (`jimmy@37.46.16.109`, project at `/home/jimmy/Soroka`):
+   ```bash
+   cd /home/jimmy/Soroka && git pull && sudo systemctl restart soroka.service
+   ```
+3. Verify: process a real meeting file that has diarization + a participants list. Expect in `journalctl -u soroka.service`:
+   - the branch log "UI подтверждения сопоставления включён …",
+   - the **confirmation message with buttons** delivered to the user,
+   - no `400 Invalid schema ... SpeakerMappingSchema` errors.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Part 1 (schema `extra=forbid`) → Task 1, Step 3. ✅
+- Part 2 (`get_json_schema` enforcement) → Task 1, Step 4. ✅
+- Part 3 (typed exception + loud marker + graceful degrade) → Task 2, Steps 3-5. ✅
+- Spec test #1 (root closed + strict) → Task 1, `test_speaker_mapping_schema_root_is_closed`. ✅
+- Spec test #2 (parametrized guard over all schemas) → Task 1, `test_all_strict_schema_roots_are_closed`. ✅
+- Spec test #3 (Dict fields keep typed additionalProperties) → Task 1, `test_dict_fields_keep_typed_additional_properties`. ✅
+- Spec test #4 (failure logs marker, returns ({}, "general")) → Task 2, `test_mapping_llm_failure_is_loud_and_degrades` (+ negative test for empty-but-successful). ✅
+- Verification (local schema regen, ruff, suite) → Task 3. ✅
+- Optional metric → intentionally OUT (YAGNI): the greppable `SPEAKER_MAPPING_LLM_FAILED` ERROR marker provides the visibility; no metrics infra change. Documented here so the omission is deliberate, not a gap.
+
+**2. Placeholder scan:** No TBD/TODO/"add error handling"/"similar to" placeholders. Every code step shows complete code and exact commands.
+
+**3. Type/name consistency:** `SpeakerMappingLLMError` is defined in Task 2 Step 3 and referenced consistently in Steps 4-5 and both tests. `enforce_additional_properties_false` defined and called in Task 1 Step 4. The marker string is exactly `SPEAKER_MAPPING_LLM_FAILED` in both the implementation (Task 2 Step 5) and the assertion (Task 2 Step 1). Schema constant names match `src/models/llm_schemas.py:271-278`.

--- a/docs/superpowers/specs/2026-06-08-speaker-mapping-strict-schema-fix-design.md
+++ b/docs/superpowers/specs/2026-06-08-speaker-mapping-strict-schema-fix-design.md
@@ -1,0 +1,185 @@
+# Восстановление UI сопоставления спикеров с участниками
+
+**Дата:** 2026-06-08
+**Статус:** Дизайн утверждён, ожидает ревью спеки
+**Тип:** Исправление продакшен-регрессии
+
+## Проблема
+
+После недавних изменений исчезла функциональность, при которой пользователь
+сопоставлял спикеров (из диаризации) с участниками встречи: сообщение с
+кнопками подтверждения сопоставления **вообще перестало появляться**. Протокол
+генерируется сразу, без шага «проверьте сопоставление».
+
+Симптом подтверждён пользователем: «Сообщение с кнопками вообще не появляется».
+
+## Корневая причина (подтверждена на проде)
+
+Прод (`/home/jimmy/Soroka`, `soroka.service`) работает на коммите `a72e942`,
+провайдер LLM — OpenRouter → `openai/gpt-5-mini` (строгий Structured Outputs).
+Флаги в рантайме процесса включены: `ENABLE_SPEAKER_MAPPING=true`,
+`ENABLE_SPEAKER_MAPPING_CONFIRMATION=true`, `ENABLE_DIARIZATION=true`.
+
+Цепочка отказа (из логов journald прода, 2026-06-06):
+
+1. PR #13 («admin-only-model», убран выбор LLM пользователем) → все запросы
+   пошли в единый активный пресет `openai/gpt-5-mini` со **строгим**
+   structured outputs.
+2. `SpeakerMappingSchema` — **единственная** из 8+ схем в
+   `src/models/llm_schemas.py` без `class Config: extra = "forbid"`
+   (в git его не было никогда).
+3. Без `extra="forbid"` Pydantic не ставит `additionalProperties: false` в
+   корень схемы, но `get_json_schema` всё равно отправляет `strict: True`.
+4. OpenAI отклоняет запрос:
+   `400 — Invalid schema for response_format 'SpeakerMappingSchema':
+   In context=(), 'additionalProperties' is required to be supplied and to be false`
+   (`context=()` = корень схемы).
+5. `_call_llm_for_mapping` ловит исключение и **молча** возвращает `{}`
+   (`speaker_mapping_service.py:600-602`).
+6. `_run_speaker_mapping` → `({}, None)`; в `_process_file_optimized` условие
+   `if speaker_mapping:` ложно → ветка `enable_speaker_mapping_confirmation`
+   **полностью пропускается** (`processing/processing_service.py:391-405`).
+7. **UI сопоставления никогда не показывается.** Протокол генерируется без него.
+
+Эмпирическое подтверждение на проде (venv):
+
+```
+SPEAKER_MAPPING_SCHEMA:  root additionalProperties = <<MISSING>>  | strict=True   ← БАГ
+PROTOCOL_SCHEMA:         root additionalProperties = False        | strict=True   ← OK
+MEETING_ANALYSIS_SCHEMA: root additionalProperties = False        | strict=True   ← OK
+```
+
+Это **не** регрессия паузы/resume из рефакторинга #15. Это сломанный LLM-вызов
+сопоставления, замаскированный под «никого не удалось сопоставить» из-за двойного
+молчаливого проглатывания ошибки.
+
+## Выбранный подход: C (схема + защита генератора + громкий сбой)
+
+Рассмотренные альтернативы:
+
+- **A — минимальный**: только `extra="forbid"` в `SpeakerMappingSchema`.
+  Возвращает фичу одной строкой, но не защищает от повтора и оставляет
+  молчаливый сбой.
+- **B — A + защита `get_json_schema`**: централизует контракт strict для всех
+  схем. Закрывает весь класс багов.
+- **C — B + громкий сбой** *(выбран)*: дополнительно делает жёсткий сбой
+  LLM-вызова видимым в логах/мониторинге, чтобы будущий обрыв провайдера/схемы
+  не выключал фичу незаметно.
+
+## Детальный дизайн
+
+### Часть 1 — Фикс схемы (сам баг)
+
+**Файл:** `src/models/llm_schemas.py`, класс `SpeakerMappingSchema` (~строка 100).
+
+Добавить `class Config: extra = "forbid"` — единообразно со всеми остальными
+схемами (`ProtocolSchema`, `MeetingAnalysisSchema`, `ProtocolDataSchema`,
+`UnifiedProtocolSchema`, `ODProtocolSchema`, `TwoStage*`, `SelfReflectionSchema`).
+В результате Pydantic эмитит `additionalProperties: false` в корне схемы, и
+строгий режим OpenAI принимает `response_format`.
+
+Доказательство достаточности (транзитивно): `PROTOCOL_SCHEMA` с тем же
+провайдером и с Dict-полями (`detected_speaker_mapping: Optional[Dict[str,str]]`
+и др.) уже работает в проде — значит провайдер принимает типизированные
+`additionalProperties` у вложенных Dict, и единственное, чего не хватает
+`SpeakerMappingSchema`, — `additionalProperties:false` в корне.
+
+### Часть 2 — Защита генератора (весь класс багов)
+
+**Файл:** `src/models/llm_schemas.py`, функция `get_json_schema`.
+
+Добавить отдельный проход `enforce_additional_properties_false(schema_dict)`,
+выполняемый после `fix_required_fields`, перед формированием итогового словаря:
+
+- Рекурсивный обход узлов: сам узел, его `properties.*`, `items`, `$defs.*`.
+- Правило: если узел — объект (`type == "object"` или есть ключ `properties`)
+  **и** в нём **отсутствует** ключ `additionalProperties` → проставить
+  `additionalProperties = false`.
+- **Не трогать** узлы, где `additionalProperties` уже задан (это типизированные
+  Dict-карты вида `{type: string}` — провайдер их принимает; перезапись на
+  `false` сломала бы динамические ключи `speaker_mappings`/`confidence_scores`).
+
+Это превращает `get_json_schema` в единственную точку соблюдения контракта
+strict: ни одна будущая схема не уедет в прод с `strict:true`, но без
+`additionalProperties:false`.
+
+Требование иммутабельности из стиля проекта: проход модифицирует словарь,
+полученный из `model_json_schema()` (свежая копия на каждый вызов), а не общий
+разделяемый объект — поэтому побочных эффектов на чужие данные нет. Существующий
+`fix_required_fields` уже мутирует тот же локальный словарь in-place; новый проход
+следует тому же ограниченному паттерну в пределах функции.
+
+### Часть 3 — Громкий сбой вместо молчаливого `{}`
+
+**Файл:** `src/services/speaker_mapping_service.py`.
+
+- Ввести типизированное исключение `SpeakerMappingLLMError` (наследник
+  `Exception`) в модуле сервиса.
+- `_call_llm_for_mapping`: на ошибке вызова API/схемы (текущий `except` на
+  строке ~600) — **поднимать** `SpeakerMappingLLMError(...)` вместо `return {}`.
+  Так «жёсткий сбой» становится отличим от «успешного, но пустого результата»
+  (когда LLM честно вернул пустой mapping).
+- `map_speakers_to_participants`: добавить **отдельную** ветку
+  `except SpeakerMappingLLMError`:
+  - логировать на уровне **ERROR** с явным грепаемым маркером
+    `SPEAKER_MAPPING_LLM_FAILED` (включая провайдера и краткую причину);
+  - **деградировать мягко** — вернуть `({}, "general")`, чтобы генерация
+    протокола продолжилась (фича не должна валить весь пайплайн);
+  - опционально инкрементировать счётчик в `src/performance/metrics.py`, если
+    там есть простой хук (решается на этапе плана; не обязательно).
+- Существующий общий `except Exception` остаётся как «последний рубеж», но
+  жёсткие сбои LLM теперь идут через явную ветку и не сливаются с обычным
+  пустым результатом.
+
+Это устраняет молчаливое проглатывание (требование стиля: «никогда молча не
+глотать ошибки»), сохраняя устойчивость пайплайна.
+
+## Тесты (TDD: красный → зелёный)
+
+`tests/` (Python, pytest):
+
+1. `SPEAKER_MAPPING_SCHEMA["schema"].get("additionalProperties") is False` и
+   `SPEAKER_MAPPING_SCHEMA["strict"] is True`.
+2. **Параметризованный гард для всех схем**: для каждого предопределённого
+   `*_SCHEMA` (PROTOCOL, TWO_STAGE_*, UNIFIED, SPEAKER_MAPPING, OD, MEETING_*,
+   PROTOCOL_DATA, …) — если `strict is True`, то корень имеет
+   `additionalProperties is False`. Ловит будущие регрессии.
+3. `get_json_schema` **не затирает** типизированный `additionalProperties` у
+   Dict-полей: в `SPEAKER_MAPPING_SCHEMA` узлы `speaker_mappings` и
+   `confidence_scores` сохраняют `additionalProperties` вида `{type: ...}`,
+   а не `false`.
+4. Часть 3: при выбросе ошибки из `_call_llm_for_mapping` (замоканный вызов
+   LLM, поднимающий исключение) `map_speakers_to_participants` логирует маркер
+   `SPEAKER_MAPPING_LLM_FAILED` и возвращает `({}, "general")` без падения.
+
+Цель покрытия — по правилам проекта (80%+) для затронутых функций.
+
+## Проверка и деплой
+
+- **Локально:** повторно сгенерировать схемы — корень `SPEAKER_MAPPING_SCHEMA`
+  должен стать `additionalProperties: False`; `ruff` чистый; все тесты зелёные.
+- **Прод:** после мержа в `main` — `git pull` + `systemctl restart
+  soroka.service`. Затем реальный прогон файла с диаризацией и списком
+  участников → в журнале должна появиться ветка
+  «UI подтверждения сопоставления включён …» и **сообщение с кнопками**;
+  ошибки `400 Invalid schema ... SpeakerMappingSchema` исчезают.
+- Рестарт прода — отдельное подтверждение пользователя перед выполнением
+  (внешнее, необратимое действие).
+
+## Вне области (out of scope)
+
+- Поведение паузы/resume из рефакторинга #15 — не меняется (оно исправно).
+- Логика самого сопоставления (`_validate_mapping`, построение промпта) — без
+  изменений.
+- Выбор LLM-провайдера/пресета (PR #13) — оставляем как есть; чиним совместимость
+  схемы, а не возвращаем выбор модели.
+
+## Риски
+
+- Малый риск: после фикса корня появится новая strict-ошибка по вложенным
+  Dict-полям. Считается маловероятным, т.к. `PROTOCOL_SCHEMA` с такими же
+  Dict-полями уже работает на том же провайдере. Снимается реальным прогоном на
+  проде в шаге проверки.
+- Проход `enforce_additional_properties_false` должен корректно отличать
+  Dict-карты (типизированный `additionalProperties`) от обычных объектов —
+  покрыто тестом №3.

--- a/src/models/llm_schemas.py
+++ b/src/models/llm_schemas.py
@@ -232,6 +232,12 @@ def get_json_schema(model_class: BaseModel) -> Dict[str, Any]:
         if isinstance(items, dict):
             enforce_additional_properties_false(items)
 
+        for combiner in ("anyOf", "oneOf", "allOf"):
+            branches = node.get(combiner)
+            if isinstance(branches, list):
+                for branch in branches:
+                    enforce_additional_properties_false(branch)
+
     fix_required_fields(schema)
     enforce_additional_properties_false(schema)
 

--- a/src/models/llm_schemas.py
+++ b/src/models/llm_schemas.py
@@ -113,6 +113,9 @@ class SpeakerMappingSchema(BaseModel):
     )
     mapping_notes: str = Field(description="Заметки по сопоставлению и определению типа встречи")
 
+    class Config:
+        extra = "forbid"
+
 
 
 
@@ -202,8 +205,36 @@ def get_json_schema(model_class: BaseModel) -> Dict[str, Any]:
             for def_name, def_schema in schema_dict["$defs"].items():
                 fix_required_fields(def_schema)
     
+    def enforce_additional_properties_false(node: Dict[str, Any]) -> None:
+        """Strict Structured Outputs требует additionalProperties:false на КАЖДОМ
+        объектном узле (включая корень). Проставляем его рекурсивно, НЕ трогая
+        узлы, где additionalProperties уже задан — это типизированные Dict-карты
+        вида {"additionalProperties": {"type": "string"}}, которые провайдер
+        принимает и которые нужны для динамических ключей.
+        """
+        if not isinstance(node, dict):
+            return
+
+        if node.get("type") == "object" and "additionalProperties" not in node:
+            node["additionalProperties"] = False
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for child in properties.values():
+                enforce_additional_properties_false(child)
+
+        defs = node.get("$defs")
+        if isinstance(defs, dict):
+            for child in defs.values():
+                enforce_additional_properties_false(child)
+
+        items = node.get("items")
+        if isinstance(items, dict):
+            enforce_additional_properties_false(items)
+
     fix_required_fields(schema)
-    
+    enforce_additional_properties_false(schema)
+
     # OpenAI требует определенный формат
     return {
         "name": schema.get("title", model_class.__name__),

--- a/src/services/speaker_mapping_service.py
+++ b/src/services/speaker_mapping_service.py
@@ -592,7 +592,6 @@ class SpeakerMappingService:
                 try:
                     result = safe_json_parse(content, context="SpeakerMappingService LLM response")
                 except (ValueError, json.JSONDecodeError) as e:
-                    logger.error(f"❌ Не удалось распарсить JSON ответа от LLM для маппинга спикеров: {e}")
                     raise SpeakerMappingLLMError(f"JSON parse failed: {e}") from e
                 
                 # Краткое резюме результата (если включено логирование)
@@ -615,7 +614,6 @@ class SpeakerMappingService:
         except SpeakerMappingLLMError:
             raise
         except Exception as e:
-            logger.error(f"Ошибка при вызове LLM для сопоставления: {e}")
             raise SpeakerMappingLLMError(str(e)) from e
     
     def _validate_mapping(

--- a/src/services/speaker_mapping_service.py
+++ b/src/services/speaker_mapping_service.py
@@ -13,6 +13,15 @@ from llm_providers import llm_manager, safe_json_parse
 from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA
 
 
+class SpeakerMappingLLMError(Exception):
+    """Жёсткий сбой LLM-вызова сопоставления (ошибка API / схемы / парсинга).
+
+    Отличает реальный сбой вызова от легитимного пустого результата, когда LLM
+    честно вернул отсутствие сопоставлений. Жёсткий сбой логируется громко и
+    приводит к мягкой деградации, а не к молчаливому пустому маппингу.
+    """
+
+
 class SpeakerMappingService:
     """Сервис для сопоставления спикеров с участниками"""
     
@@ -88,6 +97,12 @@ class SpeakerMappingService:
             logger.info(f"Сопоставление завершено: {len(validated_mapping)} спикеров, тип: {meeting_type}")
             return validated_mapping, meeting_type
             
+        except SpeakerMappingLLMError as e:
+            logger.error(
+                f"SPEAKER_MAPPING_LLM_FAILED provider={llm_provider}: {e}. "
+                "Протокол будет сгенерирован без сопоставления спикеров."
+            )
+            return {}, "general"
         except Exception as e:
             logger.error(f"Ошибка при сопоставлении спикеров: {e}")
             # Возвращаем пустой mapping и general тип
@@ -578,7 +593,7 @@ class SpeakerMappingService:
                     result = safe_json_parse(content, context="SpeakerMappingService LLM response")
                 except (ValueError, json.JSONDecodeError) as e:
                     logger.error(f"❌ Не удалось распарсить JSON ответа от LLM для маппинга спикеров: {e}")
-                    return {}
+                    raise SpeakerMappingLLMError(f"JSON parse failed: {e}") from e
                 
                 # Краткое резюме результата (если включено логирование)
                 if settings.llm_debug_log:
@@ -597,9 +612,11 @@ class SpeakerMappingService:
                 # Возвращаем пустой результат
                 return {}
             
+        except SpeakerMappingLLMError:
+            raise
         except Exception as e:
             logger.error(f"Ошибка при вызове LLM для сопоставления: {e}")
-            return {}
+            raise SpeakerMappingLLMError(str(e)) from e
     
     def _validate_mapping(
         self,

--- a/tests/test_llm_schemas_strict.py
+++ b/tests/test_llm_schemas_strict.py
@@ -47,3 +47,16 @@ def test_dict_fields_keep_typed_additional_properties():
         ap = props[field].get("additionalProperties")
         assert isinstance(ap, dict), f"{field} should keep a typed additionalProperties"
         assert ap is not False
+
+
+def test_nested_defs_objects_are_closed():
+    """Nested submodels hoisted to $defs must also get additionalProperties:false."""
+    from src.models.llm_schemas import UNIFIED_PROTOCOL_SCHEMA
+
+    defs = UNIFIED_PROTOCOL_SCHEMA["schema"].get("$defs", {})
+    assert defs, "expected at least one nested $defs entry (e.g. SelfReflectionSchema)"
+    for def_name, def_schema in defs.items():
+        if def_schema.get("type") == "object":
+            assert def_schema.get("additionalProperties") is False, (
+                f"$defs.{def_name}: nested object must set additionalProperties=false"
+            )

--- a/tests/test_llm_schemas_strict.py
+++ b/tests/test_llm_schemas_strict.py
@@ -1,0 +1,49 @@
+"""Strict Structured Outputs schema compliance.
+
+OpenAI/Azure strict mode requires `additionalProperties: false` on every object
+schema node (including the root) whenever `strict: true` is sent. SpeakerMappingSchema
+historically lacked this at the root, which made the speaker-mapping LLM call fail
+with HTTP 400 and silently disabled the speaker-mapping confirmation UI.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _all_predefined_schemas():
+    from src.models import llm_schemas
+
+    names = [n for n in dir(llm_schemas) if n.endswith("_SCHEMA")]
+    return [(n, getattr(llm_schemas, n)) for n in names]
+
+
+def test_speaker_mapping_schema_root_is_closed():
+    from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA
+
+    assert SPEAKER_MAPPING_SCHEMA["strict"] is True
+    assert SPEAKER_MAPPING_SCHEMA["schema"].get("additionalProperties") is False
+
+
+@pytest.mark.parametrize("name,schema", _all_predefined_schemas())
+def test_all_strict_schema_roots_are_closed(name, schema):
+    if schema.get("strict") is True:
+        root = schema["schema"]
+        assert root.get("additionalProperties") is False, (
+            f"{name}: strict schema root must set additionalProperties=false"
+        )
+
+
+def test_dict_fields_keep_typed_additional_properties():
+    """Dict[str, T] maps must keep their typed additionalProperties, NOT be
+    overwritten with false (that would forbid the dynamic keys the LLM fills)."""
+    from src.models.llm_schemas import SPEAKER_MAPPING_SCHEMA
+
+    props = SPEAKER_MAPPING_SCHEMA["schema"]["properties"]
+    for field in ("speaker_mappings", "confidence_scores"):
+        ap = props[field].get("additionalProperties")
+        assert isinstance(ap, dict), f"{field} should keep a typed additionalProperties"
+        assert ap is not False

--- a/tests/test_speaker_mapping_failure.py
+++ b/tests/test_speaker_mapping_failure.py
@@ -1,0 +1,93 @@
+"""The speaker-mapping LLM call must fail LOUDLY, not silently.
+
+A hard LLM/API error (e.g. HTTP 400 invalid schema) must be distinguishable from
+a genuinely-empty mapping. The service raises SpeakerMappingLLMError internally and
+map_speakers_to_participants logs a greppable marker, then degrades to ({}, "general")
+so the protocol still generates.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.mark.asyncio
+async def test_mapping_llm_failure_is_loud_and_degrades(monkeypatch):
+    from loguru import logger
+    from src.services.speaker_mapping_service import (
+        SpeakerMappingService,
+        SpeakerMappingLLMError,
+    )
+
+    service = SpeakerMappingService()
+
+    # Force a non-empty speakers_info so we reach the LLM call, and a trivial prompt.
+    monkeypatch.setattr(
+        service,
+        "_extract_speakers_info",
+        lambda *a, **k: [{"speaker": "SPEAKER_1", "samples": ["привет"]}],
+    )
+    monkeypatch.setattr(service, "_build_mapping_prompt", lambda *a, **k: "prompt")
+
+    async def _raise(*a, **k):
+        raise SpeakerMappingLLMError("HTTP 400 invalid schema")
+
+    monkeypatch.setattr(service, "_call_llm_for_mapping", _raise)
+
+    # Capture loguru ERROR output.
+    records = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        mapping, meeting_type = await service.map_speakers_to_participants(
+            diarization_data={"speakers": ["SPEAKER_1"], "segments": []},
+            participants=[{"name": "Иван Петров", "role": "PM"}],
+            transcription_text="...",
+            llm_provider="openai",
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert mapping == {}
+    assert meeting_type == "general"
+    assert any("SPEAKER_MAPPING_LLM_FAILED" in str(r) for r in records), (
+        "hard LLM failure must be logged with the SPEAKER_MAPPING_LLM_FAILED marker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_mapping_is_not_treated_as_failure(monkeypatch):
+    """A successful call returning no confident matches is NOT a failure: no marker."""
+    from loguru import logger
+    from src.services.speaker_mapping_service import SpeakerMappingService
+
+    service = SpeakerMappingService()
+    monkeypatch.setattr(
+        service,
+        "_extract_speakers_info",
+        lambda *a, **k: [{"speaker": "SPEAKER_1", "samples": ["привет"]}],
+    )
+    monkeypatch.setattr(service, "_build_mapping_prompt", lambda *a, **k: "prompt")
+
+    async def _empty(*a, **k):
+        return {"meeting_type": "business", "speaker_mappings": {}}
+
+    monkeypatch.setattr(service, "_call_llm_for_mapping", _empty)
+
+    records = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        mapping, meeting_type = await service.map_speakers_to_participants(
+            diarization_data={"speakers": ["SPEAKER_1"], "segments": []},
+            participants=[{"name": "Иван Петров", "role": "PM"}],
+            transcription_text="...",
+            llm_provider="openai",
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert mapping == {}
+    assert meeting_type == "business"
+    assert not any("SPEAKER_MAPPING_LLM_FAILED" in str(r) for r in records)

--- a/tests/test_speaker_mapping_failure.py
+++ b/tests/test_speaker_mapping_failure.py
@@ -17,9 +17,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 @pytest.mark.asyncio
 async def test_mapping_llm_failure_is_loud_and_degrades(monkeypatch):
     from loguru import logger
+
     from src.services.speaker_mapping_service import (
-        SpeakerMappingService,
         SpeakerMappingLLMError,
+        SpeakerMappingService,
     )
 
     service = SpeakerMappingService()
@@ -61,6 +62,7 @@ async def test_mapping_llm_failure_is_loud_and_degrades(monkeypatch):
 async def test_empty_mapping_is_not_treated_as_failure(monkeypatch):
     """A successful call returning no confident matches is NOT a failure: no marker."""
     from loguru import logger
+
     from src.services.speaker_mapping_service import SpeakerMappingService
 
     service = SpeakerMappingService()


### PR DESCRIPTION
## Проблема

После перехода на единый «активный пресет» LLM (PR #13) исчез шаг, где пользователь сопоставляет спикеров с участниками встречи — сообщение с кнопками подтверждения перестало появляться, протокол сразу генерировался без него.

## Корневая причина (подтверждена на проде)

Прод использует OpenRouter → `openai/gpt-5-mini` со **строгим** Structured Outputs. `SpeakerMappingSchema` — единственная из 8+ схем без `extra = "forbid"`, поэтому её JSON Schema не имела `additionalProperties: false` в корне, хотя в запрос шло `strict: true`. OpenAI отклонял вызов сопоставления с `HTTP 400 — Invalid schema ... In context=(), 'additionalProperties' is required to be supplied and to be false`. Ошибка **молча** проглатывалась (`return {}`), пустой маппинг был неотличим от «никого не сопоставили», и ветка показа UI подтверждения (`if speaker_mapping:`) пропускалась.

## Что изменено

- **Схема (`src/models/llm_schemas.py`)**
  - `SpeakerMappingSchema`: добавлен `class Config: extra = "forbid"` (как у всех остальных схем) → корень получает `additionalProperties: false`.
  - `get_json_schema`: добавлен проход `enforce_additional_properties_false` — рекурсивно проставляет `additionalProperties: false` на всех object-узлах (`properties`/`$defs`/`items`/`anyOf`/`oneOf`/`allOf`), **не трогая** типизированные Dict-карты. Теперь ни одна будущая strict-схема не уедет невалидной. Попутно закрывает и второй strict-вызов (`openai_provider`).

- **Громкий сбой (`src/services/speaker_mapping_service.py`)**
  - Введён `SpeakerMappingLLMError`; оба места молчаливого `return {}` в `_call_llm_for_mapping` теперь поднимают его.
  - `map_speakers_to_participants` ловит его, логирует единый грепаемый маркер `SPEAKER_MAPPING_LLM_FAILED` и мягко деградирует к `({}, "general")` — пайплайн не падает, но сбой провайдера/схемы больше не будет незаметным.

- **Документация:** спека и план в `docs/superpowers/{specs,plans}/`.

## Тесты

- `tests/test_llm_schemas_strict.py` — корень всех strict-схем закрыт; Dict-карты сохраняют типизированный `additionalProperties`; вложенные `$defs` закрыты.
- `tests/test_speaker_mapping_failure.py` — жёсткий сбой логирует маркер и деградирует; успешный пустой результат **не** считается сбоем (без маркера).

## Проверка

- [x] `pytest tests/` — **136 passed**
- [x] `ruff check .` — clean (CI-гейт)
- [x] Локально: корень `SPEAKER_MAPPING_SCHEMA` → `additionalProperties: false`, `strict: true`

## План тестирования на проде (после мержа)

- [ ] `git pull` + `systemctl restart soroka.service`
- [ ] Прогнать встречу с диаризацией и списком участников
- [ ] Убедиться: появляется сообщение с кнопками сопоставления; в логах нет `400 Invalid schema ... SpeakerMappingSchema`

## Известные ограничения (вне scope)

- `OD_PROTOCOL_SCHEMA.tasks` — свободная типизированная Dict-карта без `properties`; потенциально может дать 400 в strict-режиме у OD-протоколов. Пред-существующее, не затрагивается этим PR — кандидат на отдельный тикет.
- Схемы используют Pydantic v1 `class Config` (deprecation warnings) — единообразно по всему модулю; миграция на `ConfigDict` — отдельная задача.
