### PR TITLE
fix(audio-preview): decouple from mapping UI + audio-file fallback

### DIFF
--- a/src/reliability/telegram_rate_limiter.py
+++ b/src/reliability/telegram_rate_limiter.py
@@ -11,6 +11,18 @@ from typing import Any, Callable, Dict, Optional
 from aiogram.exceptions import TelegramBadRequest, TelegramRetryAfter
 from loguru import logger
 
+# Перманентные ошибки Telegram, ретрай которых бессмыслен (запрос всегда будет
+# отклонён с тем же результатом). Напр. VOICE_MESSAGES_FORBIDDEN — получатель
+# запретил голосовые сообщения в настройках приватности.
+_NON_RETRYABLE_MARKERS = (
+    "VOICE_MESSAGES_FORBIDDEN",
+)
+
+
+def is_non_retryable_telegram_error(error_message: str) -> bool:
+    """True, если ошибка перманентна и ретрай бессмыслен."""
+    return any(marker in error_message for marker in _NON_RETRYABLE_MARKERS)
+
 
 @dataclass
 class FloodControlState:
@@ -293,6 +305,10 @@ class TelegramRateLimiter:
                         return None
                 else:
                     logger.error(f"Ошибка Telegram API: {e}")
+                    # Перманентные ошибки (напр. VOICE_MESSAGES_FORBIDDEN) ретраить
+                    # бессмысленно — выходим сразу, без задержек и спама в логах.
+                    if is_non_retryable_telegram_error(str(e)):
+                        return None
                     if attempt < max_retries:
                         await asyncio.sleep(0.5 * (attempt + 1))
                         continue

--- a/src/services/processing/processing_service.py
+++ b/src/services/processing/processing_service.py
@@ -502,25 +502,6 @@ class ProcessingService(BaseProcessingService):
 
             speakers_text = transcription_result.speakers_text
 
-            # Аудиопревью: присылаем голосовой фрагмент на каждого спикера ПЕРЕД
-            # сообщением с клавиатурой. Обёрнуто в try/except — превью не должно
-            # мешать показу UI сопоставления.
-            try:
-                from src.ux.speaker_audio_preview import send_speaker_audio_previews
-                await send_speaker_audio_previews(
-                    bot=progress_tracker.bot,
-                    chat_id=progress_tracker.chat_id,
-                    user_id=request.user_id,
-                    speakers=all_speakers,
-                    diarization_data=transcription_result.diarization,
-                    temp_file_path=temp_file_path,
-                    speakers_text=speakers_text,
-                )
-            except Exception as preview_error:
-                logger.warning(
-                    f"Не удалось отправить аудиопревью спикеров: {preview_error}"
-                )
-
             confirmation_message = await show_mapping_confirmation(
                 bot=progress_tracker.bot,
                 chat_id=progress_tracker.chat_id,
@@ -564,6 +545,29 @@ class ProcessingService(BaseProcessingService):
                 logger.info(
                     "Обработка приостановлена - ожидаю подтверждения от пользователя"
                 )
+
+                # Аудиопревью спикеров: запускаем ФОНОВОЙ задачей ПОСЛЕ показа
+                # карточки. Отправка голосовых/аудио (с ретраями и возможным
+                # VOICE_MESSAGES_FORBIDDEN) не должна блокировать, задерживать или
+                # менять порядок UI сопоставления.
+                try:
+                    from src.ux.speaker_audio_preview import (
+                        schedule_speaker_audio_previews,
+                    )
+                    schedule_speaker_audio_previews(
+                        bot=progress_tracker.bot,
+                        chat_id=progress_tracker.chat_id,
+                        user_id=request.user_id,
+                        speakers=all_speakers,
+                        diarization_data=transcription_result.diarization,
+                        temp_file_path=temp_file_path,
+                        speakers_text=speakers_text,
+                    )
+                except Exception as preview_error:
+                    logger.warning(
+                        f"Не удалось запланировать аудиопревью спикеров: {preview_error}"
+                    )
+
                 return None  # pause processing
 
         logger.warning(

--- a/src/utils/telegram_safe.py
+++ b/src/utils/telegram_safe.py
@@ -333,6 +333,55 @@ async def safe_send_voice(
         return None
 
 
+async def safe_send_audio(
+    bot,
+    chat_id: int,
+    audio: Union[str, FSInputFile],
+    caption: Optional[str] = None,
+    parse_mode: Optional[str] = None,
+    disable_notification: Optional[bool] = None,
+    **kwargs
+) -> Optional[Message]:
+    """
+    Безопасная отправка аудиофайла через bot
+
+    Используется как фолбэк для голосовых сообщений: sendAudio не подпадает под
+    запрет голосовых (VOICE_MESSAGES_FORBIDDEN), поэтому получатель всё равно
+    получит фрагмент — как обычный аудиофайл.
+
+    Args:
+        bot: Экземпляр бота
+        chat_id: ID чата
+        audio: Путь к аудиофайлу или FSInputFile
+        caption: Подпись к аудио
+        parse_mode: Режим парсинга
+        disable_notification: Отключить уведомление
+        **kwargs: Дополнительные параметры
+
+    Returns:
+        Отправленное сообщение или None при ошибке
+    """
+    try:
+        result = await telegram_rate_limiter.safe_send_with_retry(
+            bot.send_audio,
+            chat_id=chat_id,
+            audio=audio,
+            caption=caption,
+            parse_mode=parse_mode,
+            disable_notification=disable_notification,
+            **kwargs
+        )
+
+        if result is None:
+            logger.warning(f"Не удалось отправить аудиофайл в чат {chat_id}")
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Критическая ошибка в safe_send_audio: {e}")
+        return None
+
+
 async def safe_bot_edit_message(
     bot,
     chat_id: int,

--- a/src/ux/speaker_audio_preview.py
+++ b/src/ux/speaker_audio_preview.py
@@ -1,9 +1,13 @@
 """Оркестратор аудиопревью спикеров.
 
-При показе UI сопоставления присылает по одному голосовому сообщению на каждого
-спикера: окно выбирается из сегментов диаризации, фрагмент режется из оригинального
-файла через ffmpeg и отправляется как voice. Фича вспомогательная — любая ошибка
-логируется и проглатывается, сопоставление это не ломает.
+При показе UI сопоставления присылает по одному фрагменту речи на каждого спикера:
+окно выбирается из сегментов диаризации, фрагмент режется из оригинального файла
+через ffmpeg и отправляется голосовым сообщением. Если голосовые запрещены у
+получателя (VOICE_MESSAGES_FORBIDDEN) — фолбэк на обычный аудиофайл.
+
+Фича вспомогательная: запускается ФОНОВОЙ задачей (``schedule_speaker_audio_previews``)
+и не блокирует и не задерживает показ карточки сопоставления; любая ошибка
+логируется и проглатывается.
 """
 
 import asyncio
@@ -14,9 +18,12 @@ from loguru import logger
 
 from src.config import settings
 from src.services.audio_fragment_service import cut_voice_fragment, select_fragment_window
-from src.utils.telegram_safe import safe_send_voice
+from src.utils.telegram_safe import safe_send_audio, safe_send_voice
 
 _MAX_CAPTION_SNIPPET = 120
+
+# Удерживаем ссылки на фоновые задачи, чтобы их не собрал GC до завершения.
+_background_tasks: set = set()
 
 
 def _preview_dir() -> str:
@@ -25,7 +32,7 @@ def _preview_dir() -> str:
 
 
 def _build_caption(speaker_id: str, speakers_text: Optional[Dict[str, str]]) -> str:
-    """Подпись голосового: '🔊 SPEAKER_N' + короткий однострочный сниппет текста."""
+    """Подпись фрагмента: '🔊 SPEAKER_N' + короткий однострочный сниппет текста."""
     caption = f"🔊 {speaker_id}"
     if speakers_text:
         text = (speakers_text.get(speaker_id) or "").strip().replace("\n", " ")
@@ -68,6 +75,29 @@ async def _prepare_clip(
     return out_path
 
 
+async def _send_clip(bot: Any, chat_id: int, clip_path: str, caption: str) -> Optional[Any]:
+    """Отправить клип голосовым; при неудаче — фолбэк на обычный аудиофайл.
+
+    Голосовые могут быть запрещены настройками приватности получателя
+    (VOICE_MESSAGES_FORBIDDEN). sendAudio под этот запрет не подпадает, поэтому
+    получатель всё равно получит фрагмент — как аудиофайл.
+    """
+    from aiogram.types import FSInputFile
+
+    message = await safe_send_voice(
+        bot, chat_id=chat_id, voice=FSInputFile(clip_path),
+        caption=caption, parse_mode=None,
+    )
+    if message is not None:
+        return message
+
+    logger.info("Аудиопревью: голосовое не отправлено, фолбэк на аудиофайл")
+    return await safe_send_audio(
+        bot, chat_id=chat_id, audio=FSInputFile(clip_path),
+        caption=caption, parse_mode=None,
+    )
+
+
 async def send_speaker_audio_previews(
     bot: Any,
     chat_id: int,
@@ -77,10 +107,10 @@ async def send_speaker_audio_previews(
     temp_file_path: Optional[str],
     speakers_text: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Прислать голосовые фрагменты речи каждого спикера.
+    """Прислать фрагменты речи каждого спикера.
 
     Никогда не пробрасывает исключения — фича вспомогательная и не должна мешать
-    показу UI сопоставления.
+    сопоставлению. Обычно запускается через ``schedule_speaker_audio_previews``.
     """
     try:
         if not settings.speaker_audio_preview_enabled:
@@ -89,9 +119,7 @@ async def send_speaker_audio_previews(
             logger.info("Аудиопревью: исходный файл недоступен, пропускаю превью")
             return
 
-        # Нарезаем все клипы параллельно, чтобы не задерживать показ UI.
-        from aiogram.types import FSInputFile
-
+        # Нарезаем все клипы параллельно.
         clip_paths = await asyncio.gather(
             *[
                 _prepare_clip(speaker_id, diarization_data, temp_file_path, user_id)
@@ -108,13 +136,7 @@ async def send_speaker_audio_previews(
             if not clip:
                 continue
             try:
-                await safe_send_voice(
-                    bot,
-                    chat_id=chat_id,
-                    voice=FSInputFile(clip),
-                    caption=_build_caption(speaker_id, speakers_text),
-                    parse_mode=None,
-                )
+                await _send_clip(bot, chat_id, clip, _build_caption(speaker_id, speakers_text))
             except Exception as send_error:
                 logger.warning(f"Аудиопревью: ошибка отправки {speaker_id}: {send_error}")
             finally:
@@ -126,3 +148,41 @@ async def send_speaker_audio_previews(
 
     except Exception as e:
         logger.error(f"Аудиопревью: непредвиденная ошибка, пропускаю превью: {e}", exc_info=True)
+
+
+def schedule_speaker_audio_previews(
+    bot: Any,
+    chat_id: int,
+    user_id: int,
+    speakers: List[str],
+    diarization_data: Dict[str, Any],
+    temp_file_path: Optional[str],
+    speakers_text: Optional[Dict[str, str]] = None,
+) -> Optional[asyncio.Task]:
+    """Запланировать отправку аудиопревью ФОНОВОЙ задачей (fire-and-forget).
+
+    Возвращает управление немедленно — НЕ блокирует и не задерживает показ карточки
+    сопоставления (в этом и была причина прежней регрессии: встроенный ``await``
+    на падающих отправках голосовых стопорил UI). Ссылка на задачу удерживается,
+    чтобы её не собрал сборщик мусора до завершения.
+    """
+    try:
+        task = asyncio.create_task(
+            send_speaker_audio_previews(
+                bot=bot,
+                chat_id=chat_id,
+                user_id=user_id,
+                speakers=speakers,
+                diarization_data=diarization_data,
+                temp_file_path=temp_file_path,
+                speakers_text=speakers_text,
+            )
+        )
+    except RuntimeError as e:
+        # Нет активного event loop — в боте не случается; на всякий случай не падаем.
+        logger.warning(f"Аудиопревью: не удалось запланировать фоновую задачу: {e}")
+        return None
+
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task

--- a/tests/test_mapping_audio_preview_wiring.py
+++ b/tests/test_mapping_audio_preview_wiring.py
@@ -1,4 +1,9 @@
-"""Превью аудио вызывается ПЕРЕД показом UI сопоставления и не ломает его при ошибке."""
+"""Аудиопревью планируется ФОНОМ ПОСЛЕ показа карточки и не ломает паузу при ошибке.
+
+Регрессия, которую это закрывает: раньше превью awaitилось ВСТРОЕННО перед показом
+карточки, и падающие отправки голосовых (VOICE_MESSAGES_FORBIDDEN + ретраи) на ~8с
+блокировали и сбивали порядок UI сопоставления.
+"""
 
 import os
 import sys
@@ -48,7 +53,7 @@ def _make_args():
     return request, transcription_result, progress_tracker, processing_metrics
 
 
-def _patch_common(monkeypatch, call_log, previews_raises=False):
+def _patch_common(monkeypatch, call_log, schedule_raises=False):
     import src.services.mapping_state_cache as msc
     import src.utils.telegram_safe as ts
     import src.ux.speaker_audio_preview as preview
@@ -64,12 +69,15 @@ def _patch_common(monkeypatch, call_log, previews_raises=False):
 
     monkeypatch.setattr(ts, "safe_edit_text", fake_edit)
 
-    async def fake_previews(**kwargs):
-        call_log.append("previews")
-        if previews_raises:
-            raise RuntimeError("ffmpeg exploded")
+    # schedule_speaker_audio_previews — СИНХРОННАЯ, возвращает управление сразу
+    # (fire-and-forget), не awaitится в проде.
+    def fake_schedule(**kwargs):
+        call_log.append("schedule")
+        if schedule_raises:
+            raise RuntimeError("scheduling failed")
+        return None
 
-    monkeypatch.setattr(preview, "send_speaker_audio_previews", fake_previews)
+    monkeypatch.setattr(preview, "schedule_speaker_audio_previews", fake_schedule)
 
     async def fake_show(**kwargs):
         call_log.append("show")
@@ -79,7 +87,7 @@ def _patch_common(monkeypatch, call_log, previews_raises=False):
 
 
 @pytest.mark.asyncio
-async def test_previews_called_before_show(monkeypatch):
+async def test_previews_scheduled_after_show(monkeypatch):
     call_log = []
     _patch_common(monkeypatch, call_log)
 
@@ -97,14 +105,15 @@ async def test_previews_called_before_show(monkeypatch):
     )
 
     assert result is None  # пауза
-    assert "previews" in call_log and "show" in call_log
-    assert call_log.index("previews") < call_log.index("show")
+    assert "show" in call_log and "schedule" in call_log
+    # Карточка показывается ПЕРВОЙ; аудио планируется уже после — не блокирует UI.
+    assert call_log.index("show") < call_log.index("schedule")
 
 
 @pytest.mark.asyncio
-async def test_preview_failure_does_not_block_show(monkeypatch):
+async def test_schedule_failure_does_not_block_pause(monkeypatch):
     call_log = []
-    _patch_common(monkeypatch, call_log, previews_raises=True)
+    _patch_common(monkeypatch, call_log, schedule_raises=True)
 
     service = _make_service()
     request, tr, pt, pm = _make_args()
@@ -120,4 +129,4 @@ async def test_preview_failure_does_not_block_show(monkeypatch):
     )
 
     assert result is None  # пауза всё равно наступает
-    assert "show" in call_log  # UI сопоставления показан несмотря на ошибку превью
+    assert "show" in call_log  # карточка показана несмотря на ошибку планирования

--- a/tests/test_rate_limiter_no_retry.py
+++ b/tests/test_rate_limiter_no_retry.py
@@ -1,0 +1,20 @@
+"""Перманентные Telegram-ошибки (напр. VOICE_MESSAGES_FORBIDDEN) не должны ретраиться."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.reliability.telegram_rate_limiter import is_non_retryable_telegram_error
+
+
+def test_voice_messages_forbidden_is_non_retryable():
+    assert is_non_retryable_telegram_error(
+        "Telegram server says - Bad Request: VOICE_MESSAGES_FORBIDDEN"
+    ) is True
+
+
+def test_transient_errors_are_retryable():
+    assert is_non_retryable_telegram_error("Bad Request: message text is empty") is False
+    assert is_non_retryable_telegram_error("connection reset") is False
+    assert is_non_retryable_telegram_error("") is False

--- a/tests/test_safe_send_voice.py
+++ b/tests/test_safe_send_voice.py
@@ -54,3 +54,51 @@ async def test_safe_send_voice_swallows_exceptions(monkeypatch):
 
     result = await ts.safe_send_voice(FakeBot(), chat_id=1, voice="x.ogg")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_safe_send_audio_calls_rate_limited_send(monkeypatch):
+    import src.utils.telegram_safe as ts
+
+    calls = {}
+
+    async def fake_safe_send_with_retry(method, **kwargs):
+        calls["method"] = method
+        calls["kwargs"] = kwargs
+        return "SENT"
+
+    monkeypatch.setattr(
+        ts.telegram_rate_limiter, "safe_send_with_retry", fake_safe_send_with_retry
+    )
+
+    class FakeBot:
+        async def send_audio(self, **kwargs):
+            return None
+
+    bot = FakeBot()
+    result = await ts.safe_send_audio(
+        bot, chat_id=123, audio="path/clip.ogg", caption="🔊 SPEAKER_1"
+    )
+
+    assert result == "SENT"
+    assert calls["method"] == bot.send_audio
+    assert calls["kwargs"]["chat_id"] == 123
+    assert calls["kwargs"]["audio"] == "path/clip.ogg"
+    assert calls["kwargs"]["caption"] == "🔊 SPEAKER_1"
+
+
+@pytest.mark.asyncio
+async def test_safe_send_audio_swallows_exceptions(monkeypatch):
+    import src.utils.telegram_safe as ts
+
+    async def boom(method, **kwargs):
+        raise RuntimeError("telegram down")
+
+    monkeypatch.setattr(ts.telegram_rate_limiter, "safe_send_with_retry", boom)
+
+    class FakeBot:
+        async def send_audio(self, **kwargs):
+            return None
+
+    result = await ts.safe_send_audio(FakeBot(), chat_id=1, audio="x.ogg")
+    assert result is None

--- a/tests/test_speaker_audio_preview.py
+++ b/tests/test_speaker_audio_preview.py
@@ -167,3 +167,98 @@ async def test_disabled_by_config_sends_nothing(monkeypatch, tmp_path):
         speakers_text={},
     )
     assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_audio_when_voice_fails(monkeypatch, tmp_path):
+    src = tmp_path / "audio.wav"
+    src.write_bytes(b"fake-audio")
+
+    voice_calls = []
+    audio_calls = []
+
+    async def fake_cut(src_path, start, duration, out_path, **k):
+        with open(out_path, "wb") as f:
+            f.write(b"ogg")
+        return True
+
+    async def fake_voice(bot, chat_id, voice, caption=None, **k):
+        voice_calls.append(caption)
+        return None  # голосовые запрещены / не ушли
+
+    async def fake_audio(bot, chat_id, audio, caption=None, **k):
+        audio_calls.append(caption)
+        return "MSG"
+
+    monkeypatch.setattr(preview, "cut_voice_fragment", fake_cut)
+    monkeypatch.setattr(preview, "safe_send_voice", fake_voice)
+    monkeypatch.setattr(preview, "safe_send_audio", fake_audio)
+
+    await preview.send_speaker_audio_previews(
+        bot=object(), chat_id=1, user_id=7,
+        speakers=["SPEAKER_1"],
+        diarization_data=_diarization(),
+        temp_file_path=str(src),
+        speakers_text={"SPEAKER_1": "привет всем"},
+    )
+
+    assert len(voice_calls) == 1  # голосовое пробуем первым
+    assert len(audio_calls) == 1  # и падаем в фолбэк на аудиофайл
+    assert "SPEAKER_1" in audio_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_no_audio_fallback_when_voice_succeeds(monkeypatch, tmp_path):
+    src = tmp_path / "audio.wav"
+    src.write_bytes(b"fake-audio")
+
+    audio_calls = []
+
+    async def fake_cut(src_path, start, duration, out_path, **k):
+        with open(out_path, "wb") as f:
+            f.write(b"ogg")
+        return True
+
+    async def fake_voice(bot, chat_id, voice, caption=None, **k):
+        return "MSG"
+
+    async def fake_audio(bot, chat_id, audio, caption=None, **k):
+        audio_calls.append(caption)
+        return "MSG"
+
+    monkeypatch.setattr(preview, "cut_voice_fragment", fake_cut)
+    monkeypatch.setattr(preview, "safe_send_voice", fake_voice)
+    monkeypatch.setattr(preview, "safe_send_audio", fake_audio)
+
+    await preview.send_speaker_audio_previews(
+        bot=object(), chat_id=1, user_id=7,
+        speakers=["SPEAKER_1"],
+        diarization_data=_diarization(),
+        temp_file_path=str(src),
+        speakers_text={},
+    )
+
+    assert audio_calls == []  # голосовое ушло — фолбэк не нужен
+
+
+@pytest.mark.asyncio
+async def test_schedule_runs_previews_in_background(monkeypatch):
+    ran = []
+
+    async def fake_send(**kwargs):
+        ran.append(kwargs)
+
+    monkeypatch.setattr(preview, "send_speaker_audio_previews", fake_send)
+
+    task = preview.schedule_speaker_audio_previews(
+        bot=object(), chat_id=1, user_id=7,
+        speakers=["SPEAKER_1"],
+        diarization_data=_diarization(),
+        temp_file_path="x",
+        speakers_text={},
+    )
+
+    assert task is not None
+    await task  # в проде НЕ ждём; здесь ждём, чтобы проверить, что задача отработала
+    assert len(ran) == 1
+    assert ran[0]["chat_id"] == 1


### PR DESCRIPTION
## Проблема (прод-регрессия после PR #17)
При тесте на проде: аудио не присылалось, порядок сообщений сбивался, карточка сопоставления показывалась с задержкой.

**Root cause (по логам прода):**
1. Получатель запретил голосовые → каждый `sendVoice` падал с `VOICE_MESSAGES_FORBIDDEN`. Rate-limiter **ретраил этот перманентный отказ** 3×/спикер → 12 ошибок за ~8с.
2. Аудиопревью **awaitилось встроенно ПЕРЕД `show_mapping_confirmation`** → эти ~8с блокировали показ карточки и сбивали порядок UI.

(Сама генерация протокола — путь `continue_processing…`, этот код не трогался; «протокол не формируется» — медленная gpt-5 генерация, не связана с фичей.)

## Фикс
- **Развязка:** `schedule_speaker_audio_previews()` — fire-and-forget фоновая задача, запускается **после** показа карточки. Отправка аудио больше не блокирует, не задерживает и не меняет порядок UI сопоставления.
- **Фолбэк на аудиофайл:** при неудаче `sendVoice` шлём `sendAudio` (не подпадает под запрет голосовых) — пользователь всё равно получает фрагмент.
- **Без ретраев перманентных ошибок:** `VOICE_MESSAGES_FORBIDDEN` помечен non-retryable → быстрый отказ, чистые логи.

## Test Plan
- [x] 7 новых тестов: non-retryable helper (2), `safe_send_audio` (2), фолбэк voice→audio + без фолбэка при успехе (2), фоновое планирование (1); обновлён wiring-тест (карточка → потом планирование, ошибка планирования не ломает паузу)
- [x] Полный прогон: **161 passed**, ruff чист
- [ ] Ручная проверка на проде после редеплоя: запись с 2+ спикерами → карточка появляется сразу в правильном порядке; аудиофрагменты приходят (голосовыми, либо аудиофайлами если голосовые запрещены)

🤖 Generated with [Claude Code](https://claude.com/claude-code)