### PR TITLE
fix(mapping): no premature 'Протокол готов' on pause + allow many-to-one speakers

### DIFF
--- a/src/handlers/callbacks/speaker_mapping_callbacks.py
+++ b/src/handlers/callbacks/speaker_mapping_callbacks.py
@@ -128,20 +128,10 @@ def setup_speaker_mapping_callbacks(user_service: UserService, template_service:
                     if 0 <= participant_idx < len(participants):
                         participant_name = participants[participant_idx].get('name', '')
                         if participant_name:
-                            # Проверяем, не используется ли уже этот участник другим спикером
-                            used_by = None
-                            for sid, pname in speaker_mapping.items():
-                                if sid != speaker_id and pname == participant_name:
-                                    used_by = sid
-                                    break
-
-                            if used_by:
-                                await callback.answer(
-                                    f"⚠️ Этот участник уже сопоставлен с {used_by}",
-                                    show_alert=True
-                                )
-                                return
-
+                            # Допускаем many-to-one: один участник может быть
+                            # сопоставлен нескольким спикерам. Диаризация иногда
+                            # дробит одного человека на несколько SPEAKER_N, и
+                            # пользователю нужно свести их к одному участнику.
                             speaker_mapping[speaker_id] = participant_name
                             await callback.answer("✅ Сопоставление изменено")
                         else:

--- a/src/services/task_queue_manager.py
+++ b/src/services/task_queue_manager.py
@@ -287,9 +287,10 @@ class TaskQueueManager:
         from config import settings as cfg
         from src.services.processing_service import ProcessingService
         from src.ux.progress_tracker import ProgressFactory
-        
+
         progress_tracker = None
-        
+        paused = False
+
         try:
             # Небольшая задержка для гарантии, что message_id успел сохраниться
             await asyncio.sleep(0.1)
@@ -324,6 +325,9 @@ class TaskQueueManager:
                 logger.info(f"Обработка задачи {task.task_id} приостановлена - ожидаю подтверждения от пользователя")
                 # Результат и финальный статус задачи проставит путь
                 # возобновления (continue_processing_after_mapping_confirmation).
+                # НЕ завершаем трекер: иначе появится ложное «Обработка завершена!
+                # Протокол готов» ещё ДО подтверждения сопоставления.
+                paused = True
                 return
             
             # Отправляем результат пользователю
@@ -377,8 +381,10 @@ class TaskQueueManager:
             # НЕ пробрасываем исключение - обрабатываем локально
         
         finally:
-            # КРИТИЧЕСКИ ВАЖНО: всегда завершаем трекер, даже если была ошибка
-            if progress_tracker:
+            # Завершаем трекер, даже если была ошибка — НО не на паузе для
+            # подтверждения сопоставления (там трекер уже показывает «Проверьте
+            # сопоставление», и complete_all() затёр бы его ложным «Протокол готов»).
+            if progress_tracker and not paused:
                 try:
                     logger.debug(f"Принудительное завершение трекера для задачи {task.task_id}")
                     await progress_tracker.complete_all()

--- a/tests/test_queue_pause_no_complete.py
+++ b/tests/test_queue_pause_no_complete.py
@@ -1,0 +1,105 @@
+"""Когда обработка встаёт на ПАУЗУ для подтверждения сопоставления, воркер не должен
+'завершать' прогресс-трекер (иначе появляется ложное «Обработка завершена! Протокол
+готов и будет отправлен ниже» ещё ДО подтверждения)."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _root)
+sys.path.insert(0, os.path.join(_root, "src"))
+
+
+@pytest.mark.asyncio
+async def test_paused_task_does_not_complete_tracker(monkeypatch):
+    import src.services.processing_service as ps_mod
+    import src.ux.progress_tracker as pt_mod
+    from src.services.task_queue_manager import TaskQueueManager
+
+    completed = []
+
+    tracker = SimpleNamespace(current_stage=None)
+
+    async def fake_complete_all():
+        completed.append(True)
+
+    tracker.complete_all = fake_complete_all
+
+    async def fake_create(*a, **k):
+        return tracker
+
+    monkeypatch.setattr(
+        pt_mod.ProgressFactory, "create_file_processing_tracker", fake_create
+    )
+
+    class FakeService:
+        async def process_file(self, request, progress_tracker, task_id=None):
+            return None  # пауза для подтверждения сопоставления
+
+    monkeypatch.setattr(ps_mod, "ProcessingService", FakeService)
+
+    manager = TaskQueueManager.__new__(TaskQueueManager)
+    manager.bot = SimpleNamespace()
+    manager.tasks = {}
+
+    task = SimpleNamespace(
+        task_id="t1", chat_id=1, message_id=None, request=SimpleNamespace()
+    )
+
+    await manager._process_task(task)
+
+    assert completed == [], "на паузе трекер не должен завершаться (нет ложного 'Протокол готов')"
+
+
+@pytest.mark.asyncio
+async def test_completed_task_still_completes_tracker(monkeypatch):
+    """Контроль: при НЕ-паузе (обычное завершение) трекер всё ещё завершается."""
+    import src.services.processing_service as ps_mod
+    import src.ux.progress_tracker as pt_mod
+    from src.services.task_queue_manager import TaskQueueManager
+
+    completed = []
+
+    tracker = SimpleNamespace(current_stage=None)
+
+    async def fake_complete_all():
+        completed.append(True)
+
+    tracker.complete_all = fake_complete_all
+
+    async def fake_create(*a, **k):
+        return tracker
+
+    monkeypatch.setattr(
+        pt_mod.ProgressFactory, "create_file_processing_tracker", fake_create
+    )
+
+    class FakeService:
+        async def process_file(self, request, progress_tracker, task_id=None):
+            return SimpleNamespace()  # обычный результат (не пауза)
+
+    monkeypatch.setattr(ps_mod, "ProcessingService", FakeService)
+
+    async def fake_send(*a, **k):
+        return True
+
+    manager = TaskQueueManager.__new__(TaskQueueManager)
+    manager.bot = SimpleNamespace()
+    manager.tasks = {}
+    manager._send_result_to_user = fake_send
+
+    async def fake_update_status(*a, **k):
+        return None
+
+    manager._update_task_status = fake_update_status
+
+    task = SimpleNamespace(
+        task_id="t2", chat_id=1, message_id=None, request=SimpleNamespace()
+    )
+
+    await manager._process_task(task)
+
+    assert completed == [True], "при обычном завершении трекер должен завершаться"


### PR DESCRIPTION
Две правки по фидбеку с прода.

## 1. Лишнее «Протокол готов» до подтверждения (баг)
После транскрипции, ещё **до** подтверждения сопоставления, показывалось ложное `✅ Обработка завершена! Протокол готов и будет отправлен ниже`.

**Причина:** в воркере очереди (`_process_task`) блок `finally` вызывал `progress_tracker.complete_all()` даже на пути паузы (`result is None`), затирая сообщение «Проверьте сопоставление» финальным «Протокол готов».
**Фикс:** флаг `paused` — на паузе трекер не финализируем.

## 2. Many-to-one: несколько спикеров → один участник (фича)
Диаризация иногда дробит одного человека на несколько `SPEAKER_N`. Убрал ограничение, которое блокировало выбор участника, уже назначенного другому спикеру (`⚠️ Этот участник уже сопоставлен с …`). Теперь можно свести несколько спикеров к одному участнику; при генерации протокола их реплики получают одно имя.

## Test Plan
- [x] 2 новых теста воркера: пауза → трекер НЕ завершается; обычное завершение → завершается
- [x] Полный прогон: **163 passed**, ruff чист
- [ ] Ручная проверка на проде: (а) карточка сопоставления без преждевременного «Протокол готов»; (б) можно назначить одного участника двум спикерам

🤖 Generated with [Claude Code](https://claude.com/claude-code)