### PR TITLE
fix(templates): корректный формат лог-строки миграции (loguru {})

### DIFF
--- a/src/services/template_maintenance.py
+++ b/src/services/template_maintenance.py
@@ -43,5 +43,5 @@ async def apply_template_maintenance(db) -> dict:
         deleted += await db.delete_system_template_by_name(name)
 
     result = {"renamed": renamed, "deduped": deduped, "deleted": deleted}
-    logger.info("Обслуживание шаблонов завершено: %s", result)
+    logger.info("Обслуживание шаблонов завершено: {}", result)
     return result


### PR DESCRIPTION
Лог-строка в `apply_template_maintenance` использовала `%s`, а loguru форматирует через `{}` — поэтому счётчики не подставлялись (`Обслуживание шаблонов завершено: %s`). Заменено на `{}`; теперь логируется `{renamed, deduped, deleted}`. Чисто косметика логирования, поведение/возврат не менялись. Тесты миграции: 3 passed.