### PR TITLE
fix(templates): корректный формат лог-строки синхронизации (loguru {})

### DIFF
--- a/src/services/template_service.py
+++ b/src/services/template_service.py
@@ -200,7 +200,7 @@ class TemplateService:
             
             total_templates = len(existing_templates) + created_count
             logger.info(
-                "Синхронизация стандартных шаблонов завершена: создано %s, обновлено %s, пропущено пользовательских %s",
+                "Синхронизация стандартных шаблонов завершена: создано {}, обновлено {}, пропущено пользовательских {}",
                 created_count,
                 updated_count,
                 skipped_user_templates,


### PR DESCRIPTION
Старый (не из недавних изменений) баг логирования в `init_default_templates`: строка `Синхронизация стандартных шаблонов завершена: создано %s, обновлено %s, пропущено пользовательских %s` использовала `%s`, тогда как loguru форматирует через `{}` — счётчики не подставлялись. Заменено на `{}`. Чистая косметика логирования; логика/возврат не менялись. Тест `test_init_templates_no_duplicates`: passed.