### PR TITLE
feat: graceful 402 handling — notify users and admins when LLM credits run out

### DIFF
--- a/src/llm/providers/openai_provider.py
+++ b/src/llm/providers/openai_provider.py
@@ -7,6 +7,7 @@ import openai
 from loguru import logger
 
 from src.config import settings
+from src.exceptions.processing import LLMInsufficientCreditsError
 from src.llm.base import LLMProvider
 from src.llm.json_utils import safe_json_parse
 from src.models.llm_schemas import MEETING_ANALYSIS_SCHEMA, PROTOCOL_DATA_SCHEMA
@@ -17,6 +18,18 @@ from src.prompts.prompts import (
     build_generation_system_prompt,
 )
 from src.utils.token_cache_logger import log_cached_tokens_usage
+
+
+def _is_insufficient_credits_error(exc: Exception) -> bool:
+    """Detect an OpenAI/OpenRouter ``402 Payment Required`` (out of credits) error.
+
+    Checks the SDK ``status_code`` first, then falls back to the message text so
+    the error is recognised even if it arrives wrapped or without the attribute.
+    """
+    if getattr(exc, "status_code", None) == 402:
+        return True
+    text = str(exc).lower()
+    return "error code: 402" in text or "more credits" in text
 
 
 class OpenAIProvider(LLMProvider):
@@ -237,4 +250,8 @@ class OpenAIProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Ошибка при вызове OpenAI [{step_name}]: {e}")
+            if _is_insufficient_credits_error(e):
+                raise LLMInsufficientCreditsError(
+                    str(e), provider="openai", model=selected_model
+                ) from e
             raise

--- a/src/services/task_queue_manager.py
+++ b/src/services/task_queue_manager.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 from uuid import uuid4
 
@@ -15,6 +15,10 @@ from config import settings
 from database import db
 from src.models.processing import ProcessingRequest
 from src.models.task_queue import QueuedTask, TaskPriority, TaskStatus
+
+# Не чаще одного алерта админам об окончании кредитов LLM в этот интервал —
+# при исчерпании баланса падает каждая задача, иначе админов завалит сообщениями.
+_CREDITS_ALERT_THROTTLE = timedelta(minutes=10)
 
 try:
     from src.performance.oom_protection import get_oom_protection
@@ -35,6 +39,7 @@ class TaskQueueManager:
         self.is_running = False
         self._lock = asyncio.Lock()
         self.bot = None  # Будет инициализирован при старте воркеров
+        self._last_credits_alert_at: Optional[datetime] = None
         
         # Определяем максимальное количество параллельных задач
         if settings.max_concurrent_tasks:
@@ -377,7 +382,17 @@ class TaskQueueManager:
                 )
             except Exception as send_error:
                 logger.error(f"Не удалось отправить рекомендации пользователю: {send_error}")
-            
+
+            # При исчерпании кредитов LLM — алертим админов (это сбой на нашей
+            # стороне, который ломает обработку у всех пользователей).
+            if self._is_insufficient_credits(str(e).lower()):
+                try:
+                    await self._notify_admins_insufficient_credits(e)
+                except Exception as admin_error:
+                    logger.error(
+                        f"Не удалось уведомить админов об окончании кредитов: {admin_error}"
+                    )
+
             # НЕ пробрасываем исключение - обрабатываем локально
         
         finally:
@@ -409,11 +424,81 @@ class TaskQueueManager:
             progress_tracker=progress_tracker,
         )
 
+    @staticmethod
+    def _is_insufficient_credits(error_lower: str) -> bool:
+        """Признак ошибки «закончились кредиты на LLM» (HTTP 402).
+
+        Срабатывает и на типизированном ``LLMInsufficientCreditsError`` (русское
+        «кредит»), и на сыром ответе провайдера (англ. «credits» / «402»).
+        """
+        return (
+            "кредит" in error_lower
+            or "credit" in error_lower
+            or "error code: 402" in error_lower
+        )
+
+    @staticmethod
+    def _build_admin_credits_alert(exc: Exception) -> str:
+        """Текст алерта администраторам об исчерпании кредитов LLM."""
+        details = getattr(exc, "details", None) or {}
+        model = details.get("model") if isinstance(details, dict) else None
+
+        raw = str(exc)
+        if len(raw) > 300:
+            raw = raw[:297] + "..."
+
+        model_line = f"Модель: {model}\n" if model else ""
+        return (
+            "🚨 LLM: закончились кредиты (HTTP 402)\n\n"
+            "Запросы к LLM-провайдеру падают — пользователи сейчас получают "
+            "«Сервис временно недоступен».\n\n"
+            f"{model_line}"
+            f"Детали: {raw}\n\n"
+            "➡️ Пополните баланс провайдера "
+            "(например, https://openrouter.ai/settings/credits)."
+        )
+
+    async def _notify_admins_insufficient_credits(self, exc: Exception) -> None:
+        """Уведомить администраторов об окончании кредитов LLM (с троттлингом)."""
+        if not settings.admins:
+            logger.warning(
+                "LLM 402: список ADMINS пуст — некого уведомить об окончании кредитов"
+            )
+            return
+
+        now = datetime.now()
+        if (
+            self._last_credits_alert_at is not None
+            and now - self._last_credits_alert_at < _CREDITS_ALERT_THROTTLE
+        ):
+            logger.debug("LLM 402: алерт админам пропущен (троттлинг)")
+            return
+        self._last_credits_alert_at = now
+
+        from src.utils.telegram_safe import safe_send_message
+
+        text = self._build_admin_credits_alert(exc)
+        for admin_id in settings.admins:
+            try:
+                await safe_send_message(
+                    self.bot, admin_id, text, disable_web_page_preview=True
+                )
+            except Exception as send_error:
+                logger.error(
+                    f"Не удалось уведомить админа {admin_id} об окончании кредитов: "
+                    f"{send_error}"
+                )
+        logger.info(
+            f"Алерт об окончании кредитов LLM отправлен админам: {settings.admins}"
+        )
+
     def _format_error_message(self, error_text: str) -> str:
         """Форматировать сообщение об ошибке для пользователя"""
         error_lower = error_text.lower()
-        
-        if "память" in error_lower or "memory" in error_lower:
+
+        if self._is_insufficient_credits(error_lower):
+            return "Сервис временно недоступен"
+        elif "память" in error_lower or "memory" in error_lower:
             return "Недостаточно памяти для обработки"
         elif "размер" in error_lower or "size" in error_lower:
             return "Файл слишком большой"
@@ -430,8 +515,18 @@ class TaskQueueManager:
     def _get_error_recommendation(self, error_text: str) -> str:
         """Получить рекомендации по устранению ошибки"""
         error_lower = error_text.lower()
-        
-        if "память" in error_lower or "memory" in error_lower:
+
+        if self._is_insufficient_credits(error_lower):
+            return (
+                "⚠️ **Сервис временно недоступен**\n\n"
+                "На сервисе обработки закончились ресурсы (кредиты LLM). "
+                "Это временная проблема на нашей стороне — с вашим файлом всё в порядке.\n\n"
+                "Что делать:\n"
+                "• Повторите попытку позже — мы пополним баланс\n"
+                "• Файл менять или пересжимать не нужно\n\n"
+                "🔄 Просто отправьте его снова через некоторое время."
+            )
+        elif "память" in error_lower or "memory" in error_lower:
             return (
                 "💡 **Рекомендации:**\n\n"
                 "Система перегружена. Попробуйте:\n"

--- a/tests/test_admin_credits_alert.py
+++ b/tests/test_admin_credits_alert.py
@@ -1,0 +1,78 @@
+"""Admin alerting when the LLM provider runs out of credits (HTTP 402).
+
+On a credits outage every queued task fails, so admins must be told — but only
+once per throttle window, otherwise they'd be flooded with one alert per task.
+"""
+import asyncio
+import os
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _root)
+sys.path.insert(0, os.path.join(_root, "src"))
+
+
+def _mgr(bot=None):
+    from src.services.task_queue_manager import TaskQueueManager
+
+    m = TaskQueueManager.__new__(TaskQueueManager)
+    m.bot = bot if bot is not None else object()
+    m._last_credits_alert_at = None
+    return m
+
+
+def _credits_exc():
+    from src.exceptions.processing import LLMInsufficientCreditsError
+
+    return LLMInsufficientCreditsError(
+        "Error code: 402 - requires more credits", provider="openai", model="gpt-5"
+    )
+
+
+def test_alert_sent_to_every_admin(monkeypatch):
+    import src.utils.telegram_safe as ts
+    from config import settings
+
+    sent = AsyncMock()
+    monkeypatch.setattr(ts, "safe_send_message", sent)
+    monkeypatch.setattr(settings, "admins", [111, 222])
+
+    mgr = _mgr()
+    asyncio.run(mgr._notify_admins_insufficient_credits(_credits_exc()))
+
+    assert sent.await_count == 2
+    recipients = {call.args[1] for call in sent.await_args_list}
+    assert recipients == {111, 222}
+    body = str(sent.await_args_list[0].args[2]).lower()
+    assert "кредит" in body and "402" in body
+
+
+def test_repeated_alerts_are_throttled(monkeypatch):
+    import src.utils.telegram_safe as ts
+    from config import settings
+
+    sent = AsyncMock()
+    monkeypatch.setattr(ts, "safe_send_message", sent)
+    monkeypatch.setattr(settings, "admins", [111])
+
+    mgr = _mgr()
+    mgr._last_credits_alert_at = datetime.now()  # just alerted → must stay silent
+    asyncio.run(mgr._notify_admins_insufficient_credits(_credits_exc()))
+
+    assert sent.await_count == 0
+
+
+def test_no_admins_configured_is_noop(monkeypatch):
+    import src.utils.telegram_safe as ts
+    from config import settings
+
+    sent = AsyncMock()
+    monkeypatch.setattr(ts, "safe_send_message", sent)
+    monkeypatch.setattr(settings, "admins", [])
+
+    mgr = _mgr()
+    asyncio.run(mgr._notify_admins_insufficient_credits(_credits_exc()))  # must not raise
+
+    assert sent.await_count == 0

--- a/tests/test_insufficient_credits_message.py
+++ b/tests/test_insufficient_credits_message.py
@@ -1,0 +1,54 @@
+"""User-facing messaging when the LLM provider runs out of credits (HTTP 402).
+
+The worker must tell the user it's a temporary service-side issue and must NOT
+leak the raw provider payload (which includes a user_id) nor advise sending a
+smaller/different file — retrying with another file does not help.
+"""
+import os
+import sys
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _root)
+sys.path.insert(0, os.path.join(_root, "src"))
+
+# Raw OpenRouter 402 payload as it appears in str(exception) — note the user_id.
+RAW_402 = (
+    "Error code: 402 - {'error': {'message': 'This request requires more credits, "
+    "or fewer max_tokens. You requested up to 16384 tokens, but can only afford "
+    "6109.', 'code': 402}, 'user_id': 'user_2lpA5W2gt60hAGWIkHfhzCdz90y'}"
+)
+
+
+def _mgr():
+    # Метод форматирования не использует __init__ — создаём инстанс без него.
+    from src.services.task_queue_manager import TaskQueueManager
+
+    return TaskQueueManager.__new__(TaskQueueManager)
+
+
+def test_format_error_message_detects_credits_and_does_not_leak():
+    msg = _mgr()._format_error_message(RAW_402)
+    low = msg.lower()
+    assert "недоступ" in low  # "сервис временно недоступен"
+    assert "user_id" not in low
+    assert "max_tokens" not in low
+
+
+def test_recommendation_for_credits_is_not_generic_retry():
+    rec = _mgr()._get_error_recommendation(RAW_402)
+    low = rec.lower()
+    assert "кредит" in low or "ресурс" in low
+    # Generic advice ("try a different file") is wrong for a credits outage.
+    assert "другой файл" not in low
+
+
+def test_typed_credits_exception_message_is_routed():
+    from src.exceptions.processing import LLMInsufficientCreditsError
+
+    exc = LLMInsufficientCreditsError(RAW_402, provider="openai", model="gpt-5")
+    assert "недоступ" in _mgr()._format_error_message(str(exc)).lower()
+
+
+def test_unrelated_errors_keep_generic_handling():
+    rec = _mgr()._get_error_recommendation("Файл слишком большой")
+    assert "кредит" not in rec.lower()

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,7 +1,10 @@
 """Tests for OpenAIProvider preset handling and cache invalidation."""
+import asyncio
 import importlib
 import sys
 from unittest.mock import MagicMock
+
+import pytest
 
 
 def _load_real_openai_provider():
@@ -62,3 +65,69 @@ def test_invalidate_cache_for_base_url_clears_all_matching():
     assert ("https://a.com/v1", 1) not in p._client_cache
     assert ("https://a.com/v1", 2) not in p._client_cache
     assert ("https://b.com/v1", 3) in p._client_cache
+
+
+# --- 402 / insufficient credits handling -----------------------------------
+
+
+class _Status402Error(Exception):
+    """Mimics openai.APIStatusError for HTTP 402 (status_code attribute)."""
+
+    status_code = 402
+
+    def __init__(self):
+        super().__init__("Error code: 402 - insufficient quota")
+
+
+class _Message402Error(Exception):
+    """402 surfaced only in the message text (no status_code attribute)."""
+
+    def __init__(self):
+        super().__init__(
+            "Error code: 402 - {'error': {'message': 'This request requires "
+            "more credits, or fewer max_tokens.'}}"
+        )
+
+
+class _OtherError(Exception):
+    pass
+
+
+def _provider_with_failing_client(exc):
+    OpenAIProvider = _load_real_openai_provider()
+    p = OpenAIProvider.__new__(OpenAIProvider)
+    p.default_client = None
+    client = MagicMock()
+    client.chat.completions.create.side_effect = exc
+    return p, client
+
+
+def _run_call(p, client):
+    return asyncio.run(
+        p._call_openai("sys", "usr", {"name": "x"}, "Analysis", model="m", client=client)
+    )
+
+
+def test_call_openai_raises_insufficient_credits_on_402_status():
+    """A 402 with status_code is mapped to LLMInsufficientCreditsError."""
+    from src.exceptions.processing import LLMInsufficientCreditsError
+
+    p, client = _provider_with_failing_client(_Status402Error())
+    with pytest.raises(LLMInsufficientCreditsError):
+        _run_call(p, client)
+
+
+def test_call_openai_raises_insufficient_credits_on_402_message():
+    """A 402 detected only from the message is still mapped to the typed error."""
+    from src.exceptions.processing import LLMInsufficientCreditsError
+
+    p, client = _provider_with_failing_client(_Message402Error())
+    with pytest.raises(LLMInsufficientCreditsError):
+        _run_call(p, client)
+
+
+def test_call_openai_reraises_non_credit_errors_unchanged():
+    """Unrelated errors propagate as-is (not masked as a credits error)."""
+    p, client = _provider_with_failing_client(_OtherError("boom"))
+    with pytest.raises(_OtherError):
+        _run_call(p, client)

--- a/tests/test_template_maintenance.py
+++ b/tests/test_template_maintenance.py
@@ -3,7 +3,6 @@ import pytest
 
 from src.services.template_maintenance import (
     REMOVE_NAMES,
-    RENAME_MAP,
     apply_template_maintenance,
 )
 


### PR DESCRIPTION
## Проблема

В проде (обнаружено при проверке логов) у OpenRouter закончились кредиты → каждый LLM-запрос падает с `HTTP 402`. Текущее поведение:

- **Пользователь** видел обрезанный сырой текст ошибки (с утечкой `user_id` аккаунта OpenRouter) + неверный совет «попробуйте файл поменьше» — бесполезный, т.к. ретрай при кончившихся кредитах не поможет.
- **Админ** никак не уведомлялся — сервис молча деградировал.
- Класс `LLMInsufficientCreditsError` уже существовал и проверялся в retry-логике, но **никогда не выбрасывался**.

## Изменения

**`src/llm/providers/openai_provider.py`**
- Детектор `_is_insufficient_credits_error()` (по `status_code == 402` + фоллбэк по тексту).
- В `_call_openai` 402 теперь маппится в типизированный `LLMInsufficientCreditsError` вместо сырого исключения. Побочный бонус: retry-слой (`reliability/retry.py`) уже умеет не повторять этот тип — теперь это реально срабатывает.

**`src/services/task_queue_manager.py`**
- Пользователю — понятное «Сервис временно недоступен» + корректный совет (файл менять не нужно, повторите позже). Сырой payload с `user_id` больше не утекает.
- Админам (`settings.admins`) — алерт с моделью и ссылкой на пополнение, **с троттлингом раз в 10 минут** (при исчерпании баланса падает каждая задача — без троттла админов завалило бы). Plain text, чтобы сырой ответ провайдера не ломал Markdown.

**`tests/test_template_maintenance.py`** — убран предсуществующий неиспользуемый импорт (`F401`), из-за которого падал гейт `ruff check .` (не связано с основным изменением).

## Тесты

Новые: маппинг 402 в провайдере (status/message/non-credit), маршрутизация сообщения пользователю без утечки payload, fan-out админ-алерта + троттлинг + no-op без админов.

- ✅ `pytest` — 185 passed
- ✅ `ruff check .` — clean

## ⚠️ Важно

Этот PR делает сбой **аккуратным**, но не чинит сам прод — нужно **пополнить баланс OpenRouter** (https://openrouter.ai/settings/credits), иначе генерация протоколов не работает.