### PR TITLE
fix: stop leaking an aiohttp session per processed file

### DIFF
--- a/src/services/file_service.py
+++ b/src/services/file_service.py
@@ -3,7 +3,7 @@
 """
 
 import os
-from typing import List
+from typing import List, Optional
 
 from aiogram import Bot
 from loguru import logger
@@ -11,17 +11,32 @@ from loguru import logger
 from config import settings
 from src.exceptions.file import FileError, FileSizeError, FileTypeError
 
+# Один Bot на весь процесс для запросов file-info к Telegram.
+#
+# Раньше каждый FileService создавал собственный Bot в __init__, а FileService
+# создаётся заново на каждую задачу (ProcessingService -> BaseProcessingService).
+# Внутренняя aiohttp-сессия такого Bot открывалась при get_file и НИКОГДА не
+# закрывалась — утечка одной сессии на каждый обработанный файл («Unclosed
+# client session» в логах). Общий ленивый Bot держит одну сессию на процесс
+# (закрывается на shutdown'е свипом aiohttp-сессий в src/bot.py).
+_shared_bot: Optional[Bot] = None
+
+
+def _get_file_bot() -> Bot:
+    """Вернуть общий Bot для получения file-info (создаётся лениво, переиспользуется)."""
+    global _shared_bot
+    if _shared_bot is None:
+        _shared_bot = Bot(token=settings.telegram_token)
+    return _shared_bot
+
 
 class FileService:
     """Сервис для работы с файлами"""
-    
+
     SUPPORTED_AUDIO_TYPES = ['audio', 'voice']
     SUPPORTED_VIDEO_TYPES = ['video', 'video_note']
     SUPPORTED_DOCUMENT_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.ogg', '.mp4', '.avi', '.mov', '.mkv']
-    
-    def __init__(self):
-        self.bot = Bot(token=settings.telegram_token)
-    
+
     def validate_file(self, file_obj, content_type: str, file_name: str = None) -> None:
         """Валидация файла"""
         # Проверка размера
@@ -59,7 +74,7 @@ class FileService:
     async def get_telegram_file_url(self, file_id: str) -> str:
         """Получить URL файла из Telegram"""
         try:
-            file_info = await self.bot.get_file(file_id)
+            file_info = await _get_file_bot().get_file(file_id)
             file_url = f"https://api.telegram.org/file/bot{settings.telegram_token}/{file_info.file_path}"
             logger.info(f"Получен URL файла: {file_info.file_path}")
             return file_url

--- a/tests/test_file_service_shared_bot.py
+++ b/tests/test_file_service_shared_bot.py
@@ -1,0 +1,46 @@
+"""FileService must reuse ONE process-wide Bot, not create one per instance.
+
+Regression (aiohttp session leak): a fresh FileService was built per task
+(ProcessingService -> BaseProcessingService), each creating its own aiogram Bot
+whose underlying aiohttp ClientSession (opened by get_file) was never closed —
+one leaked session per processed file. Reusing a single shared Bot means a
+single session for the whole process.
+"""
+import os
+import sys
+
+_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _root)
+sys.path.insert(0, os.path.join(_root, "src"))
+
+
+def _patch_bot(monkeypatch):
+    import src.services.file_service as fs
+
+    created = []
+
+    def fake_bot(token=None, **kwargs):
+        sentinel = object()
+        created.append(sentinel)
+        return sentinel
+
+    monkeypatch.setattr(fs, "Bot", fake_bot)
+    monkeypatch.setattr(fs, "_shared_bot", None, raising=False)
+    return fs, created
+
+
+def test_constructing_file_service_creates_no_bot(monkeypatch):
+    """Building a FileService must not open a Bot/session (it's per-task)."""
+    fs, created = _patch_bot(monkeypatch)
+    fs.FileService()
+    fs.FileService()
+    assert created == []
+
+
+def test_shared_bot_is_created_once_and_reused(monkeypatch):
+    """The file-lookup Bot is created lazily once and reused process-wide."""
+    fs, created = _patch_bot(monkeypatch)
+    b1 = fs._get_file_bot()
+    b2 = fs._get_file_bot()
+    assert b1 is b2
+    assert len(created) == 1


### PR DESCRIPTION
## Симптом

В проде в логах на каждый обработанный файл появлялось `Unclosed client session` / `Unclosed connector` (aiohttp). Найдено при систематической отладке (не связано с недавним 402 — просто совпадало по времени).

## Расследование

`Unclosed client session` = `aiohttp.ClientSession.__del__` без вызова `.close()`. В логах предупреждение появлялось **по разу на каждый запрос**, независимо от исхода — на успехе, на 402-ошибке и когда speaker-mapping пропускался. Значит, это не ошибочный путь, а одна утечка на запрос.

Из трёх мест создания aiohttp-сессий в проекте `URLService` и `OptimizedHTTPClient` закрываются корректно (`async with` / `__aexit__`). Остался единственный кандидат — операция, выполняемая в каждом запросе.

## Корневая причина

```
task_queue_manager:318   ProcessingService()          ← новый на каждую задачу
 └ BaseProcessingService:24  FileService()             ← новый на каждую задачу
    └ FileService.__init__   self.bot = Bot(token)     ← новый aiogram Bot = своя aiohttp-сессия
       └ get_file()  открывает сессию к api.telegram.org и НИКОГДА не закрывает
```

`FileService` создавал собственный `Bot` в `__init__`, а сам `FileService` пересоздаётся на каждую задачу. Сессия бота открывалась при `get_file()` и не закрывалась (у `FileService` нет ни `close()`, ни контекст-менеджера) → утечка одной aiohttp-сессии на каждый обработанный файл. Совпадает со всеми уликами: 1 утечка/запрос, по одному keep-alive соединению (один вызов getFile).

Это также объясняет существующий band-aid в `src/bot.py` (свип всех незакрытых `ClientSession` через `gc` на shutdown) — о накоплении знали, но источник не находили.

## Фикс

Один общий, лениво создаваемый `Bot` на весь процесс для запросов file-info, вместо нового на каждый `FileService`:
- `FileService()` больше не создаёт Bot/сессию при конструировании.
- `_get_file_bot()` создаёт singleton лениво и переиспользует → одна aiohttp-сессия на процесс (закрывается существующим свипом на shutdown).
- Побочный плюс: `FileService()` теперь конструируется без валидного токена (раньше упал бы `TokenValidationError`).

Никто снаружи не обращался к `FileService.bot` (проверено), поэтому атрибут убран без последствий.

## Тесты

- Конструирование `FileService` не создаёт Bot/сессию.
- Общий Bot создаётся один раз и переиспользуется.
- ✅ `pytest` — 187 passed
- ✅ `ruff check .` — clean